### PR TITLE
Refactor analyzer

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+
+	"github.com/Masterminds/semver"
 )
 
 // sourceBridges provide an adapter to SourceManagers that tailor operations
@@ -23,6 +25,7 @@ type sourceBridge interface {
 	matchesAny(id ProjectIdentifier, c1, c2 Constraint) bool
 	intersect(id ProjectIdentifier, c1, c2 Constraint) Constraint
 	verifyRootDir(path string) error
+	analyzerInfo() (string, *semver.Version)
 	deduceRemoteRepo(path string) (*remoteRepo, error)
 }
 
@@ -78,6 +81,10 @@ func (b *bridge) getProjectInfo(pa atom) (Manifest, Lock, error) {
 		return b.s.rm, b.s.rl, nil
 	}
 	return b.sm.GetProjectInfo(ProjectRoot(pa.id.netName()), pa.v)
+}
+
+func (b *bridge) analyzerInfo() (string, *semver.Version) {
+	return b.sm.AnalyzerInfo()
 }
 
 func (b *bridge) key(id ProjectIdentifier) ProjectRoot {

--- a/bridge.go
+++ b/bridge.go
@@ -12,7 +12,7 @@ import (
 // sourceBridges provide an adapter to SourceManagers that tailor operations
 // for a single solve run.
 type sourceBridge interface {
-	getProjectInfo(pa atom) (Manifest, Lock, error)
+	getManifestAndLock(pa atom) (Manifest, Lock, error)
 	listVersions(id ProjectIdentifier) ([]Version, error)
 	listPackages(id ProjectIdentifier, v Version) (PackageTree, error)
 	computeRootReach() ([]string, error)
@@ -76,7 +76,7 @@ var mkBridge func(*solver, SourceManager) sourceBridge = func(s *solver, sm Sour
 	}
 }
 
-func (b *bridge) getProjectInfo(pa atom) (Manifest, Lock, error) {
+func (b *bridge) getManifestAndLock(pa atom) (Manifest, Lock, error) {
 	if pa.id.ProjectRoot == b.s.params.ImportRoot {
 		return b.s.rm, b.s.rl, nil
 	}

--- a/bridge.go
+++ b/bridge.go
@@ -80,7 +80,7 @@ func (b *bridge) getProjectInfo(pa atom) (Manifest, Lock, error) {
 	if pa.id.ProjectRoot == b.s.params.ImportRoot {
 		return b.s.rm, b.s.rl, nil
 	}
-	return b.sm.GetProjectInfo(ProjectRoot(pa.id.netName()), pa.v)
+	return b.sm.GetManifestAndLock(ProjectRoot(pa.id.netName()), pa.v)
 }
 
 func (b *bridge) analyzerInfo() (string, *semver.Version) {

--- a/example.go
+++ b/example.go
@@ -54,7 +54,7 @@ func main() {
 
 type NaiveAnalyzer struct{}
 
-func (a NaiveAnalyzer) GetInfo(path string, n gps.ProjectRoot) (gps.Manifest, gps.Lock, error) {
+func (a NaiveAnalyzer) Analyze(path string, n gps.ProjectRoot) (gps.Manifest, gps.Lock, error) {
 	return nil, nil, nil
 }
 

--- a/example.go
+++ b/example.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Masterminds/semver"
 	"github.com/sdboyer/gps"
 )
 
@@ -55,4 +56,9 @@ type NaiveAnalyzer struct{}
 
 func (a NaiveAnalyzer) GetInfo(path string, n gps.ProjectRoot) (gps.Manifest, gps.Lock, error) {
 	return nil, nil, nil
+}
+
+func (a NaiveAnalyzer) Info() (name string, version *semver.Version) {
+	v, _ := semver.NewVersion("v0.0.1")
+	return "example-analyzer", v
 }

--- a/hash.go
+++ b/hash.go
@@ -84,6 +84,10 @@ func (s *solver) HashInputs() ([]byte, error) {
 		}
 	}
 
+	an, av := s.b.analyzerInfo()
+	h.Write([]byte(an))
+	h.Write([]byte(av.String()))
+
 	// TODO(sdboyer) overrides
 	// TODO(sdboyer) aliases
 	return h.Sum(nil), nil

--- a/hash_test.go
+++ b/hash_test.go
@@ -24,7 +24,7 @@ func TestHashInputs(t *testing.T) {
 	}
 
 	h := sha256.New()
-	for _, v := range []string{"a", "a", "1.0.0", "b", "b", "1.0.0", stdlibPkgs, appenginePkgs, "root", "", "root", "a", "b", "bar", "foo"} {
+	for _, v := range []string{"a", "a", "1.0.0", "b", "b", "1.0.0", stdlibPkgs, appenginePkgs, "root", "", "root", "a", "b", "bar", "foo", "depspec-sm-builtin", "1.0.0"} {
 		h.Write([]byte(v))
 	}
 	correct := h.Sum(nil)

--- a/manager_test.go
+++ b/manager_test.go
@@ -19,7 +19,7 @@ var bd string
 // this as open/Any constraints on everything in the import graph.
 type naiveAnalyzer struct{}
 
-func (naiveAnalyzer) GetInfo(string, ProjectRoot) (Manifest, Lock, error) {
+func (naiveAnalyzer) Analyze(string, ProjectRoot) (Manifest, Lock, error) {
 	return nil, nil, nil
 }
 

--- a/manager_test.go
+++ b/manager_test.go
@@ -23,6 +23,10 @@ func (naiveAnalyzer) GetInfo(string, ProjectRoot) (Manifest, Lock, error) {
 	return nil, nil, nil
 }
 
+func (a naiveAnalyzer) Info() (name string, version *semver.Version) {
+	return "naive-analyzer", sv("v0.0.1")
+}
+
 func sv(s string) *semver.Version {
 	sv, err := semver.NewVersion(s)
 	if err != nil {

--- a/manager_test.go
+++ b/manager_test.go
@@ -19,7 +19,7 @@ var bd string
 // this as open/Any constraints on everything in the import graph.
 type naiveAnalyzer struct{}
 
-func (naiveAnalyzer) Analyze(string, ProjectRoot) (Manifest, Lock, error) {
+func (naiveAnalyzer) DeriveManifestAndLock(string, ProjectRoot) (Manifest, Lock, error) {
 	return nil, nil, nil
 }
 
@@ -330,7 +330,7 @@ func TestGetInfoListVersionsOrdering(t *testing.T) {
 
 	pn := ProjectRoot("github.com/Masterminds/VCSTestRepo")
 
-	_, _, err = sm.GetProjectInfo(pn, NewVersion("1.0.0"))
+	_, _, err = sm.GetManifestAndLock(pn, NewVersion("1.0.0"))
 	if err != nil {
 		t.Errorf("Unexpected error from GetInfoAt %s", err)
 	}

--- a/project_manager.go
+++ b/project_manager.go
@@ -114,7 +114,7 @@ func (pm *projectManager) GetInfoAt(v Version) (Manifest, Lock, error) {
 	}
 
 	pm.crepo.mut.RLock()
-	m, l, err := pm.an.Analyze(filepath.Join(pm.ctx.GOPATH, "src", string(pm.n)), pm.n)
+	m, l, err := pm.an.DeriveManifestAndLock(filepath.Join(pm.ctx.GOPATH, "src", string(pm.n)), pm.n)
 	// TODO(sdboyer) cache results
 	pm.crepo.mut.RUnlock()
 

--- a/project_manager.go
+++ b/project_manager.go
@@ -114,7 +114,7 @@ func (pm *projectManager) GetInfoAt(v Version) (Manifest, Lock, error) {
 	}
 
 	pm.crepo.mut.RLock()
-	m, l, err := pm.an.GetInfo(filepath.Join(pm.ctx.GOPATH, "src", string(pm.n)), pm.n)
+	m, l, err := pm.an.Analyze(filepath.Join(pm.ctx.GOPATH, "src", string(pm.n)), pm.n)
 	// TODO(sdboyer) cache results
 	pm.crepo.mut.RUnlock()
 

--- a/result_test.go
+++ b/result_test.go
@@ -77,7 +77,7 @@ func BenchmarkCreateVendorTree(b *testing.B) {
 
 	// Prefetch the projects before timer starts
 	for _, lp := range r.p {
-		_, _, err := sm.GetProjectInfo(lp.Ident().ProjectRoot, lp.Version())
+		_, _, err := sm.GetManifestAndLock(lp.Ident().ProjectRoot, lp.Version())
 		if err != nil {
 			b.Errorf("failed getting project info during prefetch: %s", err)
 			clean = false

--- a/solve_basic_test.go
+++ b/solve_basic_test.go
@@ -966,7 +966,7 @@ func newdepspecSM(ds []depspec, ignore []string) *depspecSourceManager {
 	}
 }
 
-func (sm *depspecSourceManager) GetProjectInfo(n ProjectRoot, v Version) (Manifest, Lock, error) {
+func (sm *depspecSourceManager) GetManifestAndLock(n ProjectRoot, v Version) (Manifest, Lock, error) {
 	for _, ds := range sm.specs {
 		if n == ds.n && v.Matches(ds.v) {
 			return ds, dummyLock{}, nil

--- a/solve_basic_test.go
+++ b/solve_basic_test.go
@@ -977,6 +977,10 @@ func (sm *depspecSourceManager) GetProjectInfo(n ProjectRoot, v Version) (Manife
 	return nil, nil, fmt.Errorf("Project %s at version %s could not be found", n, v)
 }
 
+func (sm *depspecSourceManager) AnalyzerInfo() (string, *semver.Version) {
+	return "depspec-sm-builtin", sv("v1.0.0")
+}
+
 func (sm *depspecSourceManager) ExternalReach(n ProjectRoot, v Version) (map[string][]string, error) {
 	id := pident{n: n, v: v}
 	if m, exists := sm.rm[id]; exists {

--- a/solve_bimodal_test.go
+++ b/solve_bimodal_test.go
@@ -566,7 +566,7 @@ func (sm *bmSourceManager) ListPackages(n ProjectRoot, v Version) (PackageTree, 
 	return PackageTree{}, fmt.Errorf("Project %s at version %s could not be found", n, v)
 }
 
-func (sm *bmSourceManager) GetProjectInfo(n ProjectRoot, v Version) (Manifest, Lock, error) {
+func (sm *bmSourceManager) GetManifestAndLock(n ProjectRoot, v Version) (Manifest, Lock, error) {
 	for _, ds := range sm.specs {
 		if n == ds.n && v.Matches(ds.v) {
 			if l, exists := sm.lm[string(n)+" "+v.String()]; exists {

--- a/solver.go
+++ b/solver.go
@@ -474,7 +474,7 @@ func (s *solver) getImportsAndConstraintsOf(a atomWithPackages) ([]completeDep, 
 
 	// Work through the source manager to get project info and static analysis
 	// information.
-	m, _, err := s.b.getProjectInfo(a.a)
+	m, _, err := s.b.getManifestAndLock(a.a)
 	if err != nil {
 		return nil, err
 	}
@@ -661,7 +661,7 @@ func (s *solver) createVersionQueue(bmi bimodalIdentifier) (*versionQueue, error
 				continue
 			}
 
-			_, l, err := s.b.getProjectInfo(dep.depender)
+			_, l, err := s.b.getManifestAndLock(dep.depender)
 			if err != nil || l == nil {
 				// err being non-nil really shouldn't be possible, but the lock
 				// being nil is quite likely
@@ -1042,7 +1042,7 @@ func (s *solver) selectAtom(a atomWithPackages, pkgonly bool) {
 
 	// If this atom has a lock, pull it out so that we can potentially inject
 	// preferred versions into any bmis we enqueue
-	_, l, _ := s.b.getProjectInfo(a.a)
+	_, l, _ := s.b.getManifestAndLock(a.a)
 	var lmap map[ProjectIdentifier]Version
 	if l != nil {
 		lmap = make(map[ProjectIdentifier]Version)

--- a/source_manager.go
+++ b/source_manager.go
@@ -35,14 +35,16 @@ type SourceManager interface {
 	// import path, at the provided version.
 	ListPackages(ProjectRoot, Version) (PackageTree, error)
 
-	// GetProjectInfo returns manifest and lock information for the provided
-	// import path. gps currently requires that projects be rooted at their
+	// GetManifestAndLock returns manifest and lock information for the provided
+	// root import path.
+	//
+	// gps currently requires that projects be rooted at their
 	// repository root, necessitating that this ProjectRoot must also be a
 	// repository root.
-	GetProjectInfo(ProjectRoot, Version) (Manifest, Lock, error)
+	GetManifestAndLock(ProjectRoot, Version) (Manifest, Lock, error)
 
 	// AnalyzerInfo reports the name and version of the logic used to service
-	// AnalyzeProject().
+	// GetManifestAndLock().
 	AnalyzerInfo() (name string, version *semver.Version)
 
 	// ExportProject writes out the tree of the provided import path, at the
@@ -56,9 +58,10 @@ type SourceManager interface {
 // A ProjectAnalyzer is responsible for analyzing a given path for Manifest and
 // Lock information. Tools relying on gps must implement one.
 type ProjectAnalyzer interface {
-	// Perform analysis of the filesystem tree rooted at path, which has the
-	// root import path importRoot.
-	Analyze(path string, importRoot ProjectRoot) (Manifest, Lock, error)
+	// Perform analysis of the filesystem tree rooted at path, with the
+	// root import path importRoot, to determine the project's constraints, as
+	// indicated by a Manifest and Lock.
+	DeriveManifestAndLock(path string, importRoot ProjectRoot) (Manifest, Lock, error)
 	// Report the name and version of this ProjectAnalyzer.
 	Info() (name string, version *semver.Version)
 }
@@ -145,13 +148,13 @@ func (sm *SourceMgr) AnalyzerInfo() (name string, version *semver.Version) {
 	return sm.an.Info()
 }
 
-// GetProjectInfo returns manifest and lock information for the provided import
+// GetManifestAndLock returns manifest and lock information for the provided import
 // path. gps currently requires that projects be rooted at their repository
 // root, which means that this ProjectRoot must also be a repository root.
 //
-// The work of producing the manifest and lock information is delegated to the
-// injected ProjectAnalyzer.
-func (sm *SourceMgr) GetProjectInfo(n ProjectRoot, v Version) (Manifest, Lock, error) {
+// The work of producing the manifest and lock is delegated to the injected
+// ProjectAnalyzer's DeriveManifestAndLock() method.
+func (sm *SourceMgr) GetManifestAndLock(n ProjectRoot, v Version) (Manifest, Lock, error) {
 	pmc, err := sm.getProjectManager(n)
 	if err != nil {
 		return nil, nil, err

--- a/source_manager.go
+++ b/source_manager.go
@@ -37,7 +37,7 @@ type SourceManager interface {
 
 	// GetProjectInfo returns manifest and lock information for the provided
 	// import path. gps currently requires that projects be rooted at their
-	// repository root, which means that this ProjectRoot must also be a
+	// repository root, necessitating that this ProjectRoot must also be a
 	// repository root.
 	GetProjectInfo(ProjectRoot, Version) (Manifest, Lock, error)
 

--- a/source_manager.go
+++ b/source_manager.go
@@ -58,7 +58,7 @@ type SourceManager interface {
 type ProjectAnalyzer interface {
 	// Perform analysis of the filesystem tree rooted at path, which has the
 	// root import path importRoot.
-	GetInfo(path string, importRoot ProjectRoot) (Manifest, Lock, error)
+	Analyze(path string, importRoot ProjectRoot) (Manifest, Lock, error)
 	// Report the name and version of this ProjectAnalyzer.
 	Info() (name string, version *semver.Version)
 }


### PR DESCRIPTION
Fixes #50 

Including this information directly in the hash is actually kind of problematic, as it makes implementing tools expressly incompatible with one another. It points to the need for separating out some properties, so that tooling reading a lock file can make more granular decisions about what cross-tool compatibility means.