### PR TITLE
Better handling of solve failures in tests

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -29,19 +29,6 @@ type traceError interface {
 	traceString() string
 }
 
-type solveError struct {
-	lvl errorLevel
-	msg string
-}
-
-func newSolveError(msg string, lvl errorLevel) error {
-	return &solveError{msg: msg, lvl: lvl}
-}
-
-func (e *solveError) Error() string {
-	return e.msg
-}
-
 type noVersionError struct {
 	pn    ProjectIdentifier
 	fails []failedVersion

--- a/errors.go
+++ b/errors.go
@@ -66,11 +66,25 @@ func (e *noVersionError) traceString() string {
 	return buf.String()
 }
 
+// disjointConstraintFailure occurs when attempting to introduce an atom that
+// itself has an acceptable version, but one of its dependency constraints is
+// disjoint with one or more dependency constraints already active for that
+// identifier.
 type disjointConstraintFailure struct {
-	goal      dependency
-	failsib   []dependency
+	// goal is the dependency with the problematic constraint, forcing us to
+	// reject the atom that introduces it.
+	goal dependency
+	// failsib is the list of active dependencies that are disjoint with the
+	// goal dependency. This will be at least one, but may not be all of the
+	// active dependencies.
+	failsib []dependency
+	// nofailsib is the list of active dependencies that are NOT disjoint with
+	// the goal dependency. The total of nofailsib and failsib will always be
+	// the total number of active dependencies on target identifier.
 	nofailsib []dependency
-	c         Constraint
+	// c is the current constraint on the target identifier. It is intersection
+	// of all the active dependencies' constraints.
+	c Constraint
 }
 
 func (e *disjointConstraintFailure) Error() string {
@@ -161,15 +175,15 @@ func (e *constraintNotAllowedFailure) traceString() string {
 //
 // (This is one of the more straightforward types of failures)
 type versionNotAllowedFailure struct {
-	// The atom that was rejected by current constraints.
+	// goal is the atom that was rejected by current constraints.
 	goal atom
-	// The active dependencies that caused the atom to be rejected. Note that
-	// this only includes dependencies that actually rejected the atom, which
-	// will be at least one, but may not be all the active dependencies on the
-	// atom's identifier.
+	// failparent is the list of active dependencies that caused the atom to be
+	// rejected. Note that this only includes dependencies that actually
+	// rejected the atom, which will be at least one, but may not be all the
+	// active dependencies on the atom's identifier.
 	failparent []dependency
-	// The current constraint on the atom's identifier. This is the composite of
-	// all active dependencies' constraints.
+	// c is the current constraint on the atom's identifier. This is the intersection
+	// of all active dependencies' constraints.
 	c Constraint
 }
 

--- a/errors.go
+++ b/errors.go
@@ -128,8 +128,12 @@ func (e *disjointConstraintFailure) traceString() string {
 // constraints does not admit the currently-selected version of the target
 // project.
 type constraintNotAllowedFailure struct {
+	// The dependency with the problematic constraint that could not be
+	// introduced.
 	goal dependency
-	v    Version
+	// The (currently selected) version of the target project that was not
+	// admissible by the goal dependency.
+	v Version
 }
 
 func (e *constraintNotAllowedFailure) Error() string {

--- a/errors.go
+++ b/errors.go
@@ -206,10 +206,18 @@ func (e badOptsFailure) Error() string {
 }
 
 type sourceMismatchFailure struct {
-	shared            ProjectRoot
-	sel               []dependency
-	current, mismatch string
-	prob              atom
+	// The ProjectRoot over which there is disagreement about where it should be
+	// sourced from
+	shared ProjectRoot
+	// The current value for the network source
+	current string
+	// The mismatched value for the network source
+	mismatch string
+	// The currently selected dependencies which have agreed upon/established
+	// the given network source
+	sel []dependency
+	// The atom with the constraint that has the new, incompatible network source
+	prob atom
 }
 
 func (e *sourceMismatchFailure) Error() string {

--- a/errors.go
+++ b/errors.go
@@ -152,10 +152,21 @@ func (e *constraintNotAllowedFailure) traceString() string {
 	)
 }
 
+// versionNotAllowedFailure describes a failure where an atom is rejected
+// because its version is not allowed by current constraints.
+//
+// (This is one of the more straightforward types of failures)
 type versionNotAllowedFailure struct {
-	goal       atom
+	// The atom that was rejected by current constraints.
+	goal atom
+	// The active dependencies that caused the atom to be rejected. Note that
+	// this only includes dependencies that actually rejected the atom, which
+	// will be at least one, but may not be all the active dependencies on the
+	// atom's identifier.
 	failparent []dependency
-	c          Constraint
+	// The current constraint on the atom's identifier. This is the composite of
+	// all active dependencies' constraints.
+	c Constraint
 }
 
 func (e *versionNotAllowedFailure) Error() string {

--- a/errors.go
+++ b/errors.go
@@ -275,8 +275,17 @@ type errDeppers struct {
 	err     error
 	deppers []atom
 }
+
+// checkeeHasProblemPackagesFailure indicates that the goal atom was rejected
+// because one or more of the packages required by its deppers had errors.
+//
+// "errors" includes package nonexistence, which is indicated by a nil err in
+// the corresponding errDeppers failpkg map value.
 type checkeeHasProblemPackagesFailure struct {
-	goal    atom
+	// goal is the atom that was rejected due to problematic packages.
+	goal atom
+	// failpkg is a map of package names to the error describing the problem
+	// with them, plus a list of the selected atoms that require that package.
 	failpkg map[string]errDeppers
 }
 

--- a/satisfy.go
+++ b/satisfy.go
@@ -35,6 +35,10 @@ func (s *solver) check(a atomWithPackages, pkgonly bool) error {
 		return err
 	}
 
+	// TODO(sdboyer) this deps list contains only packages not already selected
+	// from the target atom (assuming one is selected at all). It's fine for
+	// now, but won't be good enough when we get around to doing static
+	// analysis.
 	for _, dep := range deps {
 		if err := s.checkIdentMatches(a, dep); err != nil {
 			s.traceInfo(err)

--- a/satisfy.go
+++ b/satisfy.go
@@ -239,14 +239,15 @@ func (s *solver) checkPackageImportsFromDepExist(a atomWithPackages, cdep comple
 	for _, pkg := range cdep.pl {
 		perr, has := ptree.Packages[pkg]
 		if !has || perr.Err != nil {
-			e.pl = append(e.pl, pkg)
 			if has {
 				e.prob[pkg] = perr.Err
+			} else {
+				e.prob[pkg] = nil
 			}
 		}
 	}
 
-	if len(e.pl) > 0 {
+	if len(e.prob) > 0 {
 		return e
 	}
 	return nil

--- a/solve_basic_test.go
+++ b/solve_basic_test.go
@@ -86,7 +86,6 @@ func mkAtom(info string) atom {
 		return atom{
 			id: ProjectIdentifier{
 				ProjectRoot: ProjectRoot("root"),
-				NetworkName: "root",
 			},
 			v: rootRev,
 		}

--- a/solve_basic_test.go
+++ b/solve_basic_test.go
@@ -816,8 +816,26 @@ var basicFixtures = map[string]basicFixture{
 			mkDepspec("b 1.0.0", "a 2.0.0"),
 			mkDepspec("b 2.0.0", "a 1.0.0"),
 		},
-		errp:        []string{"b", "a"},
-		maxAttempts: 2,
+		fail: &noVersionError{
+			pn: mkPI("b"),
+			fails: []failedVersion{
+				{
+					v: NewVersion("2.0.0"),
+					f: &versionNotAllowedFailure{
+						goal:       mkAtom("b 2.0.0"),
+						failparent: []dependency{mkDep("a 1.0.0", "b 1.0.0", "b")},
+						c:          mkSVC("1.0.0"),
+					},
+				},
+				{
+					v: NewVersion("1.0.0"),
+					f: &constraintNotAllowedFailure{
+						goal: mkDep("b 1.0.0", "a 2.0.0", "a"),
+						v:    NewVersion("1.0.0"),
+					},
+				},
+			},
+		},
 	},
 	"no version that matches while backtracking": {
 		ds: []depspec{

--- a/solve_basic_test.go
+++ b/solve_basic_test.go
@@ -238,6 +238,22 @@ func mkDep(atom, pdep string, pl ...string) dependency {
 	}
 }
 
+func mkADep(atom, pdep string, c Constraint, pl ...string) dependency {
+	return dependency{
+		depender: mkAtom(atom),
+		dep: completeDep{
+			ProjectConstraint: ProjectConstraint{
+				Ident: ProjectIdentifier{
+					ProjectRoot: ProjectRoot(pdep),
+					NetworkName: pdep,
+				},
+				Constraint: c,
+			},
+			pl: pl,
+		},
+	}
+}
+
 // mkPI creates a ProjectIdentifier with the ProjectRoot as the provided
 // string, and with the NetworkName normalized to be the same.
 func mkPI(root string) ProjectIdentifier {

--- a/solve_basic_test.go
+++ b/solve_basic_test.go
@@ -351,7 +351,6 @@ type specfix interface {
 	name() string
 	specs() []depspec
 	maxTries() int
-	expectErrs() []string
 	solution() map[string]Version
 	failure() error
 }
@@ -383,8 +382,6 @@ type basicFixture struct {
 	downgrade bool
 	// lock file simulator, if one's to be used at all
 	l fixLock
-	// projects expected to have errors, if any
-	errp []string
 	// solve failure expected, if any
 	fail error
 	// request up/downgrade to all projects
@@ -401,10 +398,6 @@ func (f basicFixture) specs() []depspec {
 
 func (f basicFixture) maxTries() int {
 	return f.maxAttempts
-}
-
-func (f basicFixture) expectErrs() []string {
-	return f.errp
 }
 
 func (f basicFixture) solution() map[string]Version {

--- a/solve_basic_test.go
+++ b/solve_basic_test.go
@@ -775,7 +775,27 @@ var basicFixtures = map[string]basicFixture{
 			mkDepspec("shared 2.5.0"),
 			mkDepspec("shared 3.5.0"),
 		},
-		errp: []string{"shared", "foo", "bar"},
+		fail: &noVersionError{
+			pn: mkPI("shared"),
+			fails: []failedVersion{
+				{
+					v: NewVersion("3.5.0"),
+					f: &versionNotAllowedFailure{
+						goal:       mkAtom("shared 3.5.0"),
+						failparent: []dependency{mkDep("foo 1.0.0", "shared >=2.0.0, <3.0.0", "shared")},
+						c:          mkSVC(">=2.9.0, <3.0.0"),
+					},
+				},
+				{
+					v: NewVersion("2.5.0"),
+					f: &versionNotAllowedFailure{
+						goal:       mkAtom("shared 2.5.0"),
+						failparent: []dependency{mkDep("bar 1.0.0", "shared >=2.9.0, <4.0.0", "shared")},
+						c:          mkSVC(">=2.9.0, <3.0.0"),
+					},
+				},
+			},
+		},
 	},
 	"disjoint constraints": {
 		ds: []depspec{
@@ -805,7 +825,19 @@ var basicFixtures = map[string]basicFixture{
 			mkDepspec("a 1.0.0"),
 			mkDepspec("b 1.0.0"),
 		},
-		errp: []string{"b", "root"},
+		fail: &noVersionError{
+			pn: mkPI("b"),
+			fails: []failedVersion{
+				{
+					v: NewVersion("1.0.0"),
+					f: &versionNotAllowedFailure{
+						goal:       mkAtom("b 1.0.0"),
+						failparent: []dependency{mkDep("root", "b >1.0.0", "b")},
+						c:          mkSVC(">1.0.0"),
+					},
+				},
+			},
+		},
 	},
 	// The latest versions of a and b disagree on c. An older version of either
 	// will resolve the problem. This test validates that b, which is farther
@@ -915,8 +947,19 @@ var basicFixtures = map[string]basicFixture{
 			mkDepspec("bar 3.0.0"),
 			mkDepspec("none 1.0.0"),
 		},
-		errp:        []string{"none", "foo"},
-		maxAttempts: 1,
+		fail: &noVersionError{
+			pn: mkPI("none"),
+			fails: []failedVersion{
+				{
+					v: NewVersion("1.0.0"),
+					f: &versionNotAllowedFailure{
+						goal:       mkAtom("none 1.0.0"),
+						failparent: []dependency{mkDep("foo 1.0.0", "none 2.0.0", "none")},
+						c:          mkSVC("2.0.0"),
+					},
+				},
+			},
+		},
 	},
 	// If there"s a disjoint constraint on a package, then selecting other
 	// versions of it is a waste of time: no possible versions can match. We

--- a/solve_basic_test.go
+++ b/solve_basic_test.go
@@ -805,8 +805,20 @@ var basicFixtures = map[string]basicFixture{
 			mkDepspec("shared 2.0.0"),
 			mkDepspec("shared 4.0.0"),
 		},
-		//errp: []string{"shared", "foo", "bar"}, // dart's has this...
-		errp: []string{"foo", "bar"},
+		fail: &noVersionError{
+			pn: mkPI("foo"),
+			fails: []failedVersion{
+				{
+					v: NewVersion("1.0.0"),
+					f: &disjointConstraintFailure{
+						goal:      mkDep("foo 1.0.0", "shared <=2.0.0", "shared"),
+						failsib:   []dependency{mkDep("bar 1.0.0", "shared >3.0.0", "shared")},
+						nofailsib: nil,
+						c:         mkSVC(">3.0.0"),
+					},
+				},
+			},
+		},
 	},
 	"no valid solution": {
 		ds: []depspec{

--- a/solve_basic_test.go
+++ b/solve_basic_test.go
@@ -328,6 +328,7 @@ type specfix interface {
 	maxTries() int
 	expectErrs() []string
 	solution() map[string]Version
+	failure() error
 }
 
 // A basicFixture is a declarative test fixture that can cover a wide variety of
@@ -383,6 +384,10 @@ func (f basicFixture) expectErrs() []string {
 
 func (f basicFixture) solution() map[string]Version {
 	return f.r
+}
+
+func (f basicFixture) failure() error {
+	return f.fail
 }
 
 // A table of basicFixtures, used in the basic solving test set.
@@ -487,7 +492,6 @@ var basicFixtures = map[string]basicFixture{
 			mkDepspec("foo 1.0.0", "bar from baz 1.0.0"),
 			mkDepspec("bar 1.0.0"),
 		},
-		errp: []string{"foo", "foo", "root"},
 		fail: &noVersionError{
 			pn: pinrm("foo"),
 			fails: []failedVersion{

--- a/solve_bimodal_test.go
+++ b/solve_bimodal_test.go
@@ -495,6 +495,8 @@ type bimodalFixture struct {
 	lm map[string]fixLock
 	// projects expected to have errors, if any
 	errp []string
+	// solve failure expected, if any
+	fail error
 	// request up/downgrade to all projects
 	changeall bool
 	// pkgs to ignore
@@ -519,6 +521,10 @@ func (f bimodalFixture) expectErrs() []string {
 
 func (f bimodalFixture) solution() map[string]Version {
 	return f.r
+}
+
+func (f bimodalFixture) failure() error {
+	return f.fail
 }
 
 // bmSourceManager is an SM specifically for the bimodal fixtures. It composes

--- a/solve_bimodal_test.go
+++ b/solve_bimodal_test.go
@@ -525,8 +525,6 @@ type bimodalFixture struct {
 	// map of locks for deps, if any. keys should be of the form:
 	// "<project> <version>"
 	lm map[string]fixLock
-	// projects expected to have errors, if any
-	errp []string
 	// solve failure expected, if any
 	fail error
 	// request up/downgrade to all projects
@@ -545,10 +543,6 @@ func (f bimodalFixture) specs() []depspec {
 
 func (f bimodalFixture) maxTries() int {
 	return f.maxAttempts
-}
-
-func (f bimodalFixture) expectErrs() []string {
-	return f.errp
 }
 
 func (f bimodalFixture) solution() map[string]Version {

--- a/solve_bimodal_test.go
+++ b/solve_bimodal_test.go
@@ -320,7 +320,26 @@ var bimodalFixtures = map[string]bimodalFixture{
 				pkg("a"),
 			),
 		},
-		errp: []string{"a", "root", "a"},
+		//errp: []string{"a", "root", "a"},
+		fail: &noVersionError{
+			pn: mkPI("a"),
+			fails: []failedVersion{
+				{
+					v: NewVersion("1.0.0"),
+					f: &checkeeHasProblemPackagesFailure{
+						goal: mkAtom("a 1.0.0"),
+						failpkg: map[string]errDeppers{
+							"a/foo": errDeppers{
+								err: nil, // nil indicates package is missing
+								deppers: []atom{
+									mkAtom("root"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	},
 	// Transitive deps from one project (a) get incrementally included as other
 	// deps incorporate its various packages, and fail with proper error when we

--- a/solve_bimodal_test.go
+++ b/solve_bimodal_test.go
@@ -320,7 +320,6 @@ var bimodalFixtures = map[string]bimodalFixture{
 				pkg("a"),
 			),
 		},
-		//errp: []string{"a", "root", "a"},
 		fail: &noVersionError{
 			pn: mkPI("a"),
 			fails: []failedVersion{
@@ -364,7 +363,21 @@ var bimodalFixtures = map[string]bimodalFixture{
 				pkg("d", "a/nonexistent"),
 			),
 		},
-		errp: []string{"d", "a", "d"},
+		fail: &noVersionError{
+			pn: mkPI("d"),
+			fails: []failedVersion{
+				{
+					v: NewVersion("1.0.0"),
+					f: &depHasProblemPackagesFailure{
+						goal: mkADep("d 1.0.0", "a", Any(), "a/nonexistent"),
+						v:    NewVersion("1.0.0"),
+						prob: map[string]error{
+							"a/nonexistent": nil,
+						},
+					},
+				},
+			},
+		},
 	},
 	// Check ignores on the root project
 	"ignore in double-subpkg": {

--- a/solve_test.go
+++ b/solve_test.go
@@ -157,6 +157,16 @@ func solveBimodalAndCheck(fix bimodalFixture, t *testing.T) (res Solution, err e
 func fixtureSolveSimpleChecks(fix specfix, res Solution, err error, t *testing.T) (Solution, error) {
 	if err != nil {
 		errp := fix.expectErrs()
+		fixfail := fix.failure()
+		if fixfail != nil {
+			if !reflect.DeepEqual(fixfail, err) {
+				t.Errorf("(fixture: %q) Failure mismatch:\n\t(GOT): %s\n\t(WNT): %s", fix.name(), err, fixfail)
+			}
+			return res, err
+		}
+
+		// TODO(sdboyer) remove this once transition to proper errors is
+		// complete
 		if len(errp) == 0 {
 			t.Errorf("(fixture: %q) Solver failed; error was type %T, text:\n%s", fix.name(), err, err)
 			return res, err

--- a/solve_test.go
+++ b/solve_test.go
@@ -159,6 +159,8 @@ func fixtureSolveSimpleChecks(fix specfix, soln Solution, err error, t *testing.
 		errp := fix.expectErrs()
 		fixfail := fix.failure()
 		if fixfail != nil {
+			// TODO(sdboyer) reflect.DeepEqual works for now, but once we start modeling
+			// more complex cases, this should probably become more robust
 			if !reflect.DeepEqual(fixfail, err) {
 				t.Errorf("(fixture: %q) Failure mismatch:\n\t(GOT): %s\n\t(WNT): %s", fix.name(), err, fixfail)
 			}

--- a/solve_test.go
+++ b/solve_test.go
@@ -154,7 +154,7 @@ func solveBimodalAndCheck(fix bimodalFixture, t *testing.T) (res Solution, err e
 	return fixtureSolveSimpleChecks(fix, res, err, t)
 }
 
-func fixtureSolveSimpleChecks(fix specfix, res Solution, err error, t *testing.T) (Solution, error) {
+func fixtureSolveSimpleChecks(fix specfix, soln Solution, err error, t *testing.T) (Solution, error) {
 	if err != nil {
 		errp := fix.expectErrs()
 		fixfail := fix.failure()
@@ -162,14 +162,13 @@ func fixtureSolveSimpleChecks(fix specfix, res Solution, err error, t *testing.T
 			if !reflect.DeepEqual(fixfail, err) {
 				t.Errorf("(fixture: %q) Failure mismatch:\n\t(GOT): %s\n\t(WNT): %s", fix.name(), err, fixfail)
 			}
-			return res, err
+			return soln, err
 		}
 
-		// TODO(sdboyer) remove this once transition to proper errors is
-		// complete
+		// TODO(sdboyer) remove all this after transition to proper errors
 		if len(errp) == 0 {
 			t.Errorf("(fixture: %q) Solver failed; error was type %T, text:\n%s", fix.name(), err, err)
-			return res, err
+			return soln, err
 		}
 
 		switch fail := err.(type) {
@@ -219,7 +218,7 @@ func fixtureSolveSimpleChecks(fix specfix, res Solution, err error, t *testing.T
 	} else if len(fix.expectErrs()) > 0 {
 		t.Errorf("(fixture: %q) Solver succeeded, but expected failure", fix.name())
 	} else {
-		r := res.(solution)
+		r := soln.(solution)
 		if fix.maxTries() > 0 && r.Attempts() > fix.maxTries() {
 			t.Errorf("(fixture: %q) Solver completed in %v attempts, but expected %v or fewer", fix.name(), r.att, fix.maxTries())
 		}
@@ -261,7 +260,7 @@ func fixtureSolveSimpleChecks(fix specfix, res Solution, err error, t *testing.T
 		}
 	}
 
-	return res, err
+	return soln, err
 }
 
 // This tests that, when a root lock is underspecified (has only a version) we

--- a/solver.go
+++ b/solver.go
@@ -634,7 +634,7 @@ func (s *solver) createVersionQueue(bmi bimodalIdentifier) (*versionQueue, error
 			// Project exists only in vendor (and in some manifest somewhere)
 			// TODO(sdboyer) mark this for special handling, somehow?
 		} else {
-			return nil, newSolveError(fmt.Sprintf("Project '%s' could not be located.", id), cannotResolve)
+			return nil, fmt.Errorf("Project '%s' could not be located.", id)
 		}
 	}
 

--- a/types.go
+++ b/types.go
@@ -193,7 +193,7 @@ func (awp atomWithPackages) bmi() bimodalIdentifier {
 // are the same) name, a constraint, and the actual packages needed that are
 // under that root.
 type completeDep struct {
-	// The base ProjectDep
+	// The base ProjectConstraint
 	ProjectConstraint
 	// The specific packages required from the ProjectDep
 	pl []string


### PR DESCRIPTION
Sorta related to #20, but mostly different.

This sets up a system for proper comparison of errors on fixture tests, rather than using a shitty, imprecise abstraction.

Ended up kinda being a prerequisite for #76 because it's just painful adding more error types without this.