### PR TITLE
Source Manager state management, plus signals

### DIFF
--- a/manager_test.go
+++ b/manager_test.go
@@ -780,6 +780,11 @@ func TestSignalHandling(t *testing.T) {
 	// Wait for twice the time it took to do it last time; should be safe
 	<-time.After(reldur * 2)
 
+	// proc.Signal doesn't send for windows, so just force it
+	if runtime.GOOS == "windows" {
+		sm.Release()
+	}
+
 	if sm.releasing != 1 {
 		t.Error("Releasing flag did not get set")
 	}

--- a/manager_test.go
+++ b/manager_test.go
@@ -643,3 +643,65 @@ func TestMultiFetchThreadsafe(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+func TestErrAfterRelease(t *testing.T) {
+	sm, clean := mkNaiveSM(t)
+	clean()
+	id := ProjectIdentifier{}
+
+	_, err := sm.SourceExists(id)
+	if err == nil {
+		t.Errorf("SourceExists did not error after calling Release()")
+	} else if terr, ok := err.(smIsReleased); !ok {
+		t.Errorf("SourceExists errored after Release(), but with unexpected error: %T %s", terr, terr.Error())
+	}
+
+	err = sm.SyncSourceFor(id)
+	if err == nil {
+		t.Errorf("SyncSourceFor did not error after calling Release()")
+	} else if terr, ok := err.(smIsReleased); !ok {
+		t.Errorf("SyncSourceFor errored after Release(), but with unexpected error: %T %s", terr, terr.Error())
+	}
+
+	_, err = sm.ListVersions(id)
+	if err == nil {
+		t.Errorf("ListVersions did not error after calling Release()")
+	} else if terr, ok := err.(smIsReleased); !ok {
+		t.Errorf("ListVersions errored after Release(), but with unexpected error: %T %s", terr, terr.Error())
+	}
+
+	_, err = sm.RevisionPresentIn(id, "")
+	if err == nil {
+		t.Errorf("RevisionPresentIn did not error after calling Release()")
+	} else if terr, ok := err.(smIsReleased); !ok {
+		t.Errorf("RevisionPresentIn errored after Release(), but with unexpected error: %T %s", terr, terr.Error())
+	}
+
+	_, err = sm.ListPackages(id, nil)
+	if err == nil {
+		t.Errorf("ListPackages did not error after calling Release()")
+	} else if terr, ok := err.(smIsReleased); !ok {
+		t.Errorf("ListPackages errored after Release(), but with unexpected error: %T %s", terr, terr.Error())
+	}
+
+	_, _, err = sm.GetManifestAndLock(id, nil)
+	if err == nil {
+		t.Errorf("GetManifestAndLock did not error after calling Release()")
+	} else if terr, ok := err.(smIsReleased); !ok {
+		t.Errorf("GetManifestAndLock errored after Release(), but with unexpected error: %T %s", terr, terr.Error())
+	}
+
+	err = sm.ExportProject(id, nil, "")
+	if err == nil {
+		t.Errorf("ExportProject did not error after calling Release()")
+	} else if terr, ok := err.(smIsReleased); !ok {
+		t.Errorf("ExportProject errored after Release(), but with unexpected error: %T %s", terr, terr.Error())
+	}
+
+	_, err = sm.DeduceProjectRoot("")
+	if err == nil {
+		t.Errorf("DeduceProjectRoot did not error after calling Release()")
+	} else if terr, ok := err.(smIsReleased); !ok {
+		t.Errorf("DeduceProjectRoot errored after Release(), but with unexpected error: %T %s", terr, terr.Error())
+	}
+}

--- a/source_manager.go
+++ b/source_manager.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -93,11 +94,12 @@ type SourceMgr struct {
 	an                  ProjectAnalyzer
 	dxt                 deducerTrie
 	rootxt              prTrie
-	signaled            int32
 	sigch               chan os.Signal
 	qch                 chan struct{}
-	releasing, released int32
 	glock               sync.RWMutex
+	opcount             int32
+	signaled            int32
+	releasing, released int32
 }
 
 type smIsReleased struct{}
@@ -164,7 +166,7 @@ func NewSourceManager(an ProjectAnalyzer, cachedir string) (*SourceMgr, error) {
 		dxt:      pathDeducerTrie(),
 		rootxt:   newProjectRootTrie(),
 		qch:      make(chan struct{}),
-		sigch:    make(chan os.Signal),
+		sigch:    make(chan os.Signal, 2), // buf to avoid unnecessary blocking
 	}
 
 	signal.Notify(sm.sigch, syscall.SIGINT, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGQUIT, os.Interrupt)
@@ -182,23 +184,45 @@ func NewSourceManager(an ProjectAnalyzer, cachedir string) (*SourceMgr, error) {
 					// Nice path - wait to remove the disk lock file until the
 					// global sm lock is clear.
 					if !atomic.CompareAndSwapInt32(&sm.releasing, 0, 1) {
-						// Something's already begun releasing the sm, so we
+						// Something's already called Release() on this sm, so we
 						// don't have to do anything, as we'd just be redoing
-						// that work. Instead, we can just return.
+						// that work. Instead, just return.
 						return
 					}
 
-					fmt.Println("Cleaning up...")
-					// Now, wait for the global lock to clear
+					// Things could interleave poorly here, but it would just
+					// make for confusing output, not incorrect behavior
+					var waited bool
+					if sm.opcount > 0 {
+						waited = true
+						fmt.Printf("Waiting for %v ops to complete...", sm.opcount)
+					}
+
+					// Mutex interaction in a signal handler is, as a general
+					// rule, unsafe. I'm not clear on whether the guarantees Go
+					// provides around signal handling, or having passed this
+					// through a channel in general, obviate those concerns, but
+					// to be safe, we avoid touching the mutex and immediately
+					// initiate disk cleanup.
 					sm.glock.Lock()
+					if waited && sm.released != 1 {
+						fmt.Println("done.\n")
+					}
 					sm.doRelease()
 					sm.glock.Unlock()
 				} else {
+					// As with above, a poor interleaving would only result in
+					// confusing output, not incorrect behavior
+					if sm.opcount > 0 {
+						fmt.Printf("Stopping without waiting for %v ops to complete\n", sm.opcount)
+					}
+
 					// Aggressive path - we don't care about the global lock,
 					// we're shutting down right away. We don't need to CAS
 					// releasing because it wouldn't change the behavior either
-					// way. Instead, we make sure it's marked so everything else
-					// behaves well.
+					// way. It should already be set, of course, but just to be
+					// sure, we mark it to ensure that no other reading methods
+					// could possibly begin after this point.
 					atomic.StoreInt32(&sm.releasing, 1)
 					sm.doRelease()
 				}
@@ -211,9 +235,9 @@ func NewSourceManager(an ProjectAnalyzer, cachedir string) (*SourceMgr, error) {
 		}
 	}
 
-	// Two, so that the second can hop past the global lock and immediately quit
 	go sigfunc(sm.sigch)
 	go sigfunc(sm.sigch)
+	runtime.Gosched()
 
 	return sm, nil
 }
@@ -230,7 +254,9 @@ func (e CouldNotCreateLockError) Error() string {
 	return e.Err.Error()
 }
 
-// Release lets go of any locks held by the SourceManager.
+// Release lets go of any locks held by the SourceManager. Once called, it is no
+// longer safe to call methods against it; all method calls will immediately
+// result in errors.
 func (sm *SourceMgr) Release() {
 	sm.lf.Close()
 	// This ensures a signal handling can't interleave with a Release call -

--- a/source_manager.go
+++ b/source_manager.go
@@ -269,6 +269,7 @@ func (sm *SourceMgr) StopSignalHandling() {
 	sm.sigmut.Lock()
 	if sm.qch != nil {
 		close(sm.qch)
+		sm.qch = nil
 		runtime.Gosched()
 	}
 	sm.sigmut.Unlock()

--- a/source_manager.go
+++ b/source_manager.go
@@ -90,6 +90,15 @@ type SourceMgr struct {
 	an       ProjectAnalyzer
 	dxt      deducerTrie
 	rootxt   prTrie
+	qch      chan os.Signal
+	released int32
+	glock    sync.RWMutex
+}
+
+type smIsReleased struct{}
+
+func (smIsReleased) Error() string {
+	return "this SourceMgr has been released, its methods can no longer be called"
 }
 
 type unifiedFuture struct {
@@ -167,7 +176,22 @@ func (e CouldNotCreateLockError) Error() string {
 // Release lets go of any locks held by the SourceManager.
 func (sm *SourceMgr) Release() {
 	sm.lf.Close()
+	// This ensures a signal handling can't interleave with a Release call -
+	// exit early if we're already marked as having initiated a release process.
+	//
+	// Setting it before we acquire the lock also guarantees that no _more_
+	// method calls will stack up.
+	if !atomic.CompareAndSwapInt32(&sm.released, 0, 1) {
+		return
+	}
+
+	// Grab the global sm lock so that we only release once we're sure all other
+	// calls have completed
+	//
+	// (This could deadlock, ofc)
+	sm.glock.Lock()
 	os.Remove(filepath.Join(sm.cachedir, "sm.lock"))
+	sm.glock.Unlock()
 }
 
 // AnalyzerInfo reports the name and version of the injected ProjectAnalyzer.
@@ -183,23 +207,39 @@ func (sm *SourceMgr) AnalyzerInfo() (name string, version *semver.Version) {
 // The work of producing the manifest and lock is delegated to the injected
 // ProjectAnalyzer's DeriveManifestAndLock() method.
 func (sm *SourceMgr) GetManifestAndLock(id ProjectIdentifier, v Version) (Manifest, Lock, error) {
+	if atomic.CompareAndSwapInt32(&sm.released, 1, 1) {
+		return nil, nil, smIsReleased{}
+	}
+	sm.glock.RLock()
+
 	src, err := sm.getSourceFor(id)
 	if err != nil {
+		sm.glock.RUnlock()
 		return nil, nil, err
 	}
 
-	return src.getManifestAndLock(id.ProjectRoot, v)
+	m, l, err := src.getManifestAndLock(id.ProjectRoot, v)
+	sm.glock.RUnlock()
+	return m, l, err
 }
 
 // ListPackages parses the tree of the Go packages at and below the ProjectRoot
 // of the given ProjectIdentifier, at the given version.
 func (sm *SourceMgr) ListPackages(id ProjectIdentifier, v Version) (PackageTree, error) {
+	if atomic.CompareAndSwapInt32(&sm.released, 1, 1) {
+		return PackageTree{}, smIsReleased{}
+	}
+	sm.glock.RLock()
+
 	src, err := sm.getSourceFor(id)
 	if err != nil {
+		sm.glock.RUnlock()
 		return PackageTree{}, err
 	}
 
-	return src.listPackages(id.ProjectRoot, v)
+	pt, err := src.listPackages(id.ProjectRoot, v)
+	sm.glock.RUnlock()
+	return pt, err
 }
 
 // ListVersions retrieves a list of the available versions for a given
@@ -215,36 +255,60 @@ func (sm *SourceMgr) ListPackages(id ProjectIdentifier, v Version) (PackageTree,
 // is not accessible (network outage, access issues, or the resource actually
 // went away), an error will be returned.
 func (sm *SourceMgr) ListVersions(id ProjectIdentifier) ([]Version, error) {
+	if atomic.CompareAndSwapInt32(&sm.released, 1, 1) {
+		return nil, smIsReleased{}
+	}
+	sm.glock.RLock()
+
 	src, err := sm.getSourceFor(id)
 	if err != nil {
+		sm.glock.RUnlock()
 		// TODO(sdboyer) More-er proper-er errors
 		return nil, err
 	}
 
-	return src.listVersions()
+	vl, err := src.listVersions()
+	sm.glock.RUnlock()
+	return vl, err
 }
 
 // RevisionPresentIn indicates whether the provided Revision is present in the given
 // repository.
 func (sm *SourceMgr) RevisionPresentIn(id ProjectIdentifier, r Revision) (bool, error) {
+	if atomic.CompareAndSwapInt32(&sm.released, 1, 1) {
+		return false, smIsReleased{}
+	}
+	sm.glock.RLock()
+
 	src, err := sm.getSourceFor(id)
 	if err != nil {
+		sm.glock.RUnlock()
 		// TODO(sdboyer) More-er proper-er errors
 		return false, err
 	}
 
-	return src.revisionPresentIn(r)
+	is, err := src.revisionPresentIn(r)
+	sm.glock.RUnlock()
+	return is, err
 }
 
 // SourceExists checks if a repository exists, either upstream or in the cache,
 // for the provided ProjectIdentifier.
 func (sm *SourceMgr) SourceExists(id ProjectIdentifier) (bool, error) {
+	if atomic.CompareAndSwapInt32(&sm.released, 1, 1) {
+		return false, smIsReleased{}
+	}
+	sm.glock.RLock()
+
 	src, err := sm.getSourceFor(id)
 	if err != nil {
+		sm.glock.RUnlock()
 		return false, err
 	}
 
-	return src.checkExistence(existsInCache) || src.checkExistence(existsUpstream), nil
+	exists := src.checkExistence(existsInCache) || src.checkExistence(existsUpstream)
+	sm.glock.RUnlock()
+	return exists, nil
 }
 
 // SyncSourceFor will ensure that all local caches and information about a
@@ -252,23 +316,39 @@ func (sm *SourceMgr) SourceExists(id ProjectIdentifier) (bool, error) {
 //
 // The primary use case for this is prefetching.
 func (sm *SourceMgr) SyncSourceFor(id ProjectIdentifier) error {
+	if atomic.CompareAndSwapInt32(&sm.released, 1, 1) {
+		return smIsReleased{}
+	}
+	sm.glock.RLock()
+
 	src, err := sm.getSourceFor(id)
 	if err != nil {
+		sm.glock.RUnlock()
 		return err
 	}
 
-	return src.syncLocal()
+	err = src.syncLocal()
+	sm.glock.RUnlock()
+	return err
 }
 
 // ExportProject writes out the tree of the provided ProjectIdentifier's
 // ProjectRoot, at the provided version, to the provided directory.
 func (sm *SourceMgr) ExportProject(id ProjectIdentifier, v Version, to string) error {
+	if atomic.CompareAndSwapInt32(&sm.released, 1, 1) {
+		return smIsReleased{}
+	}
+	sm.glock.RLock()
+
 	src, err := sm.getSourceFor(id)
 	if err != nil {
+		sm.glock.RUnlock()
 		return err
 	}
 
-	return src.exportVersionTo(v, to)
+	err = src.exportVersionTo(v, to)
+	sm.glock.RUnlock()
+	return err
 }
 
 // DeduceProjectRoot takes an import path and deduces the corresponding
@@ -279,6 +359,11 @@ func (sm *SourceMgr) ExportProject(id ProjectIdentifier, v Version, to string) e
 // paths. (A special exception is written for gopkg.in to minimize network
 // activity, as its behavior is well-structured)
 func (sm *SourceMgr) DeduceProjectRoot(ip string) (ProjectRoot, error) {
+	if atomic.CompareAndSwapInt32(&sm.released, 1, 1) {
+		return "", smIsReleased{}
+	}
+	sm.glock.RLock()
+
 	if prefix, root, has := sm.rootxt.LongestPrefix(ip); has {
 		// The non-matching tail of the import path could still be malformed.
 		// Validate just that part, if it exists
@@ -292,15 +377,18 @@ func (sm *SourceMgr) DeduceProjectRoot(ip string) (ProjectRoot, error) {
 			// revalidate it later
 			sm.rootxt.Insert(ip, root)
 		}
+		sm.glock.RUnlock()
 		return root, nil
 	}
 
 	ft, err := sm.deducePathAndProcess(ip)
 	if err != nil {
+		sm.glock.RUnlock()
 		return "", err
 	}
 
 	r, err := ft.rootf()
+	sm.glock.RUnlock()
 	return ProjectRoot(r), err
 }
 

--- a/source_manager.go
+++ b/source_manager.go
@@ -250,7 +250,7 @@ func (sm *SourceMgr) HandleSignals(sigch chan os.Signal) {
 				return
 			case <-qch:
 				// quit channel triggered - deregister our sigch and return
-				signal.Stop(ch)
+				signal.Stop(sch)
 				return
 			}
 		}

--- a/source_manager.go
+++ b/source_manager.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"github.com/Masterminds/semver"
@@ -172,18 +171,12 @@ func NewSourceManager(an ProjectAnalyzer, cachedir string) (*SourceMgr, error) {
 	return sm, nil
 }
 
-// SetUpSigHandling sets up typical signal handling for a SourceMgr. It will
-// register a signal handler to be notified on:
-//
-//  - syscall.SIGINT
-//  - syscall.SIGHUP
-//  - syscall.SIGTERM
-//  - syscall.SIGQUIT
-//  - os.Interrupt
+// SetUpSigHandling sets up typical os.Interrupt signal handling for a
+// SourceMgr.
 func SetUpSigHandling(sm *SourceMgr) {
-	sigch := make(chan os.Signal)
+	sigch := make(chan os.Signal, 1)
+	signal.Notify(sigch, os.Interrupt)
 	sm.HandleSignals(sigch)
-	signal.Notify(sigch, syscall.SIGINT, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGQUIT, os.Interrupt)
 }
 
 // HandleSignals sets up logic to handle incoming signals with the goal of

--- a/source_manager.go
+++ b/source_manager.go
@@ -86,21 +86,21 @@ type ProjectAnalyzer interface {
 // There's no (planned) reason why it would need to be reimplemented by other
 // tools; control via dependency injection is intended to be sufficient.
 type SourceMgr struct {
-	cachedir            string
-	lf                  *os.File
-	srcs                map[string]source
-	srcmut              sync.RWMutex
-	srcfuts             map[string]*unifiedFuture
-	srcfmut             sync.RWMutex
-	an                  ProjectAnalyzer
-	dxt                 deducerTrie
-	rootxt              prTrie
-	sigch               chan os.Signal
-	qch                 chan struct{}
-	glock               sync.RWMutex
-	opcount             int32
-	signaled            int32
-	releasing, released int32
+	cachedir  string                    // path to root of cache dir
+	lf        *os.File                  // handle for the sm lock file on disk
+	srcs      map[string]source         // map of path names to source obj
+	srcmut    sync.RWMutex              // mutex protecting srcs map
+	srcfuts   map[string]*unifiedFuture // map of paths to source-handling futures
+	srcfmut   sync.RWMutex              // mutex protecting futures map
+	an        ProjectAnalyzer           // analyzer injected by the caller
+	dxt       deducerTrie               // static trie with baseline source type deduction info
+	rootxt    prTrie                    // dynamic trie, updated as ProjectRoots are deduced
+	qch       chan struct{}             // quit chan for signal handler
+	sigmut    sync.Mutex                // mutex protecting signal handling setup/teardown
+	glock     sync.RWMutex              // global lock for all ops, sm validity
+	opcount   int32                     // number of ops in flight
+	releasing int32                     // flag indicating release of sm has begun
+	released  int32                     // flag indicating release of sm has finished
 }
 
 type smIsReleased struct{}


### PR DESCRIPTION
Fixes #86, #89

This is also prerequisite to #130, as I'm just not comfortable thinking about a persistent cache until we have tighter control over `SourceMgr` lifecycle