### PR TITLE
Gopkgin filtering

### DIFF
--- a/deduce.go
+++ b/deduce.go
@@ -282,6 +282,7 @@ func (m gopkginDeducer) deduceSource(p string, u *url.URL) (maybeSource, error) 
 		}
 		u2.Scheme = scheme
 		mb[k] = maybeGopkginSource{
+			opath: v[1],
 			url:   &u2,
 			major: major,
 		}

--- a/deduce_test.go
+++ b/deduce_test.go
@@ -111,60 +111,60 @@ var pathDeductionFixtures = map[string][]pathDeductionFixture{
 			in:   "gopkg.in/sdboyer/gps.v0",
 			root: "gopkg.in/sdboyer/gps.v0",
 			mb: maybeSources{
-				maybeGopkginSource{url: mkurl("https://github.com/sdboyer/gps"), major: 0},
-				maybeGopkginSource{url: mkurl("ssh://git@github.com/sdboyer/gps"), major: 0},
-				maybeGopkginSource{url: mkurl("git://github.com/sdboyer/gps"), major: 0},
-				maybeGopkginSource{url: mkurl("http://github.com/sdboyer/gps"), major: 0},
+				maybeGopkginSource{opath: "gopkg.in/sdboyer/gps.v0", url: mkurl("https://github.com/sdboyer/gps"), major: 0},
+				maybeGopkginSource{opath: "gopkg.in/sdboyer/gps.v0", url: mkurl("ssh://git@github.com/sdboyer/gps"), major: 0},
+				maybeGopkginSource{opath: "gopkg.in/sdboyer/gps.v0", url: mkurl("git://github.com/sdboyer/gps"), major: 0},
+				maybeGopkginSource{opath: "gopkg.in/sdboyer/gps.v0", url: mkurl("http://github.com/sdboyer/gps"), major: 0},
 			},
 		},
 		{
 			in:   "gopkg.in/sdboyer/gps.v0/foo",
 			root: "gopkg.in/sdboyer/gps.v0",
 			mb: maybeSources{
-				maybeGopkginSource{url: mkurl("https://github.com/sdboyer/gps"), major: 0},
-				maybeGopkginSource{url: mkurl("ssh://git@github.com/sdboyer/gps"), major: 0},
-				maybeGopkginSource{url: mkurl("git://github.com/sdboyer/gps"), major: 0},
-				maybeGopkginSource{url: mkurl("http://github.com/sdboyer/gps"), major: 0},
+				maybeGopkginSource{opath: "gopkg.in/sdboyer/gps.v0", url: mkurl("https://github.com/sdboyer/gps"), major: 0},
+				maybeGopkginSource{opath: "gopkg.in/sdboyer/gps.v0", url: mkurl("ssh://git@github.com/sdboyer/gps"), major: 0},
+				maybeGopkginSource{opath: "gopkg.in/sdboyer/gps.v0", url: mkurl("git://github.com/sdboyer/gps"), major: 0},
+				maybeGopkginSource{opath: "gopkg.in/sdboyer/gps.v0", url: mkurl("http://github.com/sdboyer/gps"), major: 0},
 			},
 		},
 		{
 			in:   "gopkg.in/sdboyer/gps.v1/foo/bar",
 			root: "gopkg.in/sdboyer/gps.v1",
 			mb: maybeSources{
-				maybeGopkginSource{url: mkurl("https://github.com/sdboyer/gps"), major: 1},
-				maybeGopkginSource{url: mkurl("ssh://git@github.com/sdboyer/gps"), major: 1},
-				maybeGopkginSource{url: mkurl("git://github.com/sdboyer/gps"), major: 1},
-				maybeGopkginSource{url: mkurl("http://github.com/sdboyer/gps"), major: 1},
+				maybeGopkginSource{opath: "gopkg.in/sdboyer/gps.v1", url: mkurl("https://github.com/sdboyer/gps"), major: 1},
+				maybeGopkginSource{opath: "gopkg.in/sdboyer/gps.v1", url: mkurl("ssh://git@github.com/sdboyer/gps"), major: 1},
+				maybeGopkginSource{opath: "gopkg.in/sdboyer/gps.v1", url: mkurl("git://github.com/sdboyer/gps"), major: 1},
+				maybeGopkginSource{opath: "gopkg.in/sdboyer/gps.v1", url: mkurl("http://github.com/sdboyer/gps"), major: 1},
 			},
 		},
 		{
 			in:   "gopkg.in/yaml.v1",
 			root: "gopkg.in/yaml.v1",
 			mb: maybeSources{
-				maybeGopkginSource{url: mkurl("https://github.com/go-yaml/yaml"), major: 1},
-				maybeGopkginSource{url: mkurl("ssh://git@github.com/go-yaml/yaml"), major: 1},
-				maybeGopkginSource{url: mkurl("git://github.com/go-yaml/yaml"), major: 1},
-				maybeGopkginSource{url: mkurl("http://github.com/go-yaml/yaml"), major: 1},
+				maybeGopkginSource{opath: "gopkg.in/yaml.v1", url: mkurl("https://github.com/go-yaml/yaml"), major: 1},
+				maybeGopkginSource{opath: "gopkg.in/yaml.v1", url: mkurl("ssh://git@github.com/go-yaml/yaml"), major: 1},
+				maybeGopkginSource{opath: "gopkg.in/yaml.v1", url: mkurl("git://github.com/go-yaml/yaml"), major: 1},
+				maybeGopkginSource{opath: "gopkg.in/yaml.v1", url: mkurl("http://github.com/go-yaml/yaml"), major: 1},
 			},
 		},
 		{
 			in:   "gopkg.in/yaml.v1/foo/bar",
 			root: "gopkg.in/yaml.v1",
 			mb: maybeSources{
-				maybeGopkginSource{url: mkurl("https://github.com/go-yaml/yaml"), major: 1},
-				maybeGopkginSource{url: mkurl("ssh://git@github.com/go-yaml/yaml"), major: 1},
-				maybeGopkginSource{url: mkurl("git://github.com/go-yaml/yaml"), major: 1},
-				maybeGopkginSource{url: mkurl("http://github.com/go-yaml/yaml"), major: 1},
+				maybeGopkginSource{opath: "gopkg.in/yaml.v1", url: mkurl("https://github.com/go-yaml/yaml"), major: 1},
+				maybeGopkginSource{opath: "gopkg.in/yaml.v1", url: mkurl("ssh://git@github.com/go-yaml/yaml"), major: 1},
+				maybeGopkginSource{opath: "gopkg.in/yaml.v1", url: mkurl("git://github.com/go-yaml/yaml"), major: 1},
+				maybeGopkginSource{opath: "gopkg.in/yaml.v1", url: mkurl("http://github.com/go-yaml/yaml"), major: 1},
 			},
 		},
 		{
 			in:   "gopkg.in/inf.v0",
 			root: "gopkg.in/inf.v0",
 			mb: maybeSources{
-				maybeGopkginSource{url: mkurl("https://github.com/go-inf/inf"), major: 0},
-				maybeGopkginSource{url: mkurl("ssh://git@github.com/go-inf/inf"), major: 0},
-				maybeGopkginSource{url: mkurl("git://github.com/go-inf/inf"), major: 0},
-				maybeGopkginSource{url: mkurl("http://github.com/go-inf/inf"), major: 0},
+				maybeGopkginSource{opath: "gopkg.in/inf.v0", url: mkurl("https://github.com/go-inf/inf"), major: 0},
+				maybeGopkginSource{opath: "gopkg.in/inf.v0", url: mkurl("ssh://git@github.com/go-inf/inf"), major: 0},
+				maybeGopkginSource{opath: "gopkg.in/inf.v0", url: mkurl("git://github.com/go-inf/inf"), major: 0},
+				maybeGopkginSource{opath: "gopkg.in/inf.v0", url: mkurl("http://github.com/go-inf/inf"), major: 0},
 			},
 		},
 		{
@@ -506,7 +506,7 @@ func TestDeduceFromPath(t *testing.T) {
 			case maybeHgSource:
 				return fmt.Sprintf("%T: %s", tmb, ufmt(tmb.url))
 			case maybeGopkginSource:
-				return fmt.Sprintf("%T: %s (v%v)", tmb, ufmt(tmb.url), tmb.major)
+				return fmt.Sprintf("%T: %s (v%v) %s ", tmb, tmb.opath, tmb.major, ufmt(tmb.url))
 			default:
 				t.Errorf("Unknown maybeSource type: %T", mb)
 				t.FailNow()

--- a/deduce_test.go
+++ b/deduce_test.go
@@ -111,60 +111,60 @@ var pathDeductionFixtures = map[string][]pathDeductionFixture{
 			in:   "gopkg.in/sdboyer/gps.v0",
 			root: "gopkg.in/sdboyer/gps.v0",
 			mb: maybeSources{
-				maybeGitSource{url: mkurl("https://github.com/sdboyer/gps")},
-				maybeGitSource{url: mkurl("ssh://git@github.com/sdboyer/gps")},
-				maybeGitSource{url: mkurl("git://github.com/sdboyer/gps")},
-				maybeGitSource{url: mkurl("http://github.com/sdboyer/gps")},
+				maybeGopkginSource{url: mkurl("https://github.com/sdboyer/gps"), major: 0},
+				maybeGopkginSource{url: mkurl("ssh://git@github.com/sdboyer/gps"), major: 0},
+				maybeGopkginSource{url: mkurl("git://github.com/sdboyer/gps"), major: 0},
+				maybeGopkginSource{url: mkurl("http://github.com/sdboyer/gps"), major: 0},
 			},
 		},
 		{
 			in:   "gopkg.in/sdboyer/gps.v0/foo",
 			root: "gopkg.in/sdboyer/gps.v0",
 			mb: maybeSources{
-				maybeGitSource{url: mkurl("https://github.com/sdboyer/gps")},
-				maybeGitSource{url: mkurl("ssh://git@github.com/sdboyer/gps")},
-				maybeGitSource{url: mkurl("git://github.com/sdboyer/gps")},
-				maybeGitSource{url: mkurl("http://github.com/sdboyer/gps")},
+				maybeGopkginSource{url: mkurl("https://github.com/sdboyer/gps"), major: 0},
+				maybeGopkginSource{url: mkurl("ssh://git@github.com/sdboyer/gps"), major: 0},
+				maybeGopkginSource{url: mkurl("git://github.com/sdboyer/gps"), major: 0},
+				maybeGopkginSource{url: mkurl("http://github.com/sdboyer/gps"), major: 0},
 			},
 		},
 		{
 			in:   "gopkg.in/sdboyer/gps.v1/foo/bar",
 			root: "gopkg.in/sdboyer/gps.v1",
 			mb: maybeSources{
-				maybeGitSource{url: mkurl("https://github.com/sdboyer/gps")},
-				maybeGitSource{url: mkurl("ssh://git@github.com/sdboyer/gps")},
-				maybeGitSource{url: mkurl("git://github.com/sdboyer/gps")},
-				maybeGitSource{url: mkurl("http://github.com/sdboyer/gps")},
+				maybeGopkginSource{url: mkurl("https://github.com/sdboyer/gps"), major: 1},
+				maybeGopkginSource{url: mkurl("ssh://git@github.com/sdboyer/gps"), major: 1},
+				maybeGopkginSource{url: mkurl("git://github.com/sdboyer/gps"), major: 1},
+				maybeGopkginSource{url: mkurl("http://github.com/sdboyer/gps"), major: 1},
 			},
 		},
 		{
 			in:   "gopkg.in/yaml.v1",
 			root: "gopkg.in/yaml.v1",
 			mb: maybeSources{
-				maybeGitSource{url: mkurl("https://github.com/go-yaml/yaml")},
-				maybeGitSource{url: mkurl("ssh://git@github.com/go-yaml/yaml")},
-				maybeGitSource{url: mkurl("git://github.com/go-yaml/yaml")},
-				maybeGitSource{url: mkurl("http://github.com/go-yaml/yaml")},
+				maybeGopkginSource{url: mkurl("https://github.com/go-yaml/yaml"), major: 1},
+				maybeGopkginSource{url: mkurl("ssh://git@github.com/go-yaml/yaml"), major: 1},
+				maybeGopkginSource{url: mkurl("git://github.com/go-yaml/yaml"), major: 1},
+				maybeGopkginSource{url: mkurl("http://github.com/go-yaml/yaml"), major: 1},
 			},
 		},
 		{
 			in:   "gopkg.in/yaml.v1/foo/bar",
 			root: "gopkg.in/yaml.v1",
 			mb: maybeSources{
-				maybeGitSource{url: mkurl("https://github.com/go-yaml/yaml")},
-				maybeGitSource{url: mkurl("ssh://git@github.com/go-yaml/yaml")},
-				maybeGitSource{url: mkurl("git://github.com/go-yaml/yaml")},
-				maybeGitSource{url: mkurl("http://github.com/go-yaml/yaml")},
+				maybeGopkginSource{url: mkurl("https://github.com/go-yaml/yaml"), major: 1},
+				maybeGopkginSource{url: mkurl("ssh://git@github.com/go-yaml/yaml"), major: 1},
+				maybeGopkginSource{url: mkurl("git://github.com/go-yaml/yaml"), major: 1},
+				maybeGopkginSource{url: mkurl("http://github.com/go-yaml/yaml"), major: 1},
 			},
 		},
 		{
 			in:   "gopkg.in/inf.v0",
 			root: "gopkg.in/inf.v0",
 			mb: maybeSources{
-				maybeGitSource{url: mkurl("https://github.com/go-inf/inf")},
-				maybeGitSource{url: mkurl("ssh://git@github.com/go-inf/inf")},
-				maybeGitSource{url: mkurl("git://github.com/go-inf/inf")},
-				maybeGitSource{url: mkurl("http://github.com/go-inf/inf")},
+				maybeGopkginSource{url: mkurl("https://github.com/go-inf/inf"), major: 0},
+				maybeGopkginSource{url: mkurl("ssh://git@github.com/go-inf/inf"), major: 0},
+				maybeGopkginSource{url: mkurl("git://github.com/go-inf/inf"), major: 0},
+				maybeGopkginSource{url: mkurl("http://github.com/go-inf/inf"), major: 0},
 			},
 		},
 		{
@@ -505,6 +505,8 @@ func TestDeduceFromPath(t *testing.T) {
 				return fmt.Sprintf("%T: %s", tmb, ufmt(tmb.url))
 			case maybeHgSource:
 				return fmt.Sprintf("%T: %s", tmb, ufmt(tmb.url))
+			case maybeGopkginSource:
+				return fmt.Sprintf("%T: %s (v%v)", tmb, ufmt(tmb.url), tmb.major)
 			default:
 				t.Errorf("Unknown maybeSource type: %T", mb)
 				t.FailNow()

--- a/source_test.go
+++ b/source_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"reflect"
+	"sync"
 	"testing"
 )
 
@@ -101,6 +102,144 @@ func TestGitSourceInteractions(t *testing.T) {
 	} else if !is {
 		t.Errorf("Revision that should exist was not present on re-check")
 	}
+}
+
+func TestGopkginSourceInteractions(t *testing.T) {
+	// This test is slowish, skip it on -short
+	if testing.Short() {
+		t.Skip("Skipping gopkg.in source version fetching test in short mode")
+	}
+
+	cpath, err := ioutil.TempDir("", "smcache")
+	if err != nil {
+		t.Errorf("Failed to create temp dir: %s", err)
+	}
+	rf := func() {
+		err := removeAll(cpath)
+		if err != nil {
+			t.Errorf("removeAll failed: %s", err)
+		}
+	}
+
+	tfunc := func(n string, major int64, evl []Version) {
+		un := "https://" + n
+		u, err := url.Parse(un)
+		if err != nil {
+			t.Errorf("URL was bad, lolwut? errtext: %s", err)
+			return
+		}
+		mb := maybeGopkginSource{
+			url:   u,
+			major: major,
+		}
+
+		isrc, ident, err := mb.try(cpath, naiveAnalyzer{})
+		if err != nil {
+			t.Errorf("Unexpected error while setting up gopkginSource for test repo: %s", err)
+			return
+		}
+		src, ok := isrc.(*gopkginSource)
+		if !ok {
+			t.Errorf("Expected a gopkginSource, got a %T", isrc)
+			return
+		}
+		if ident != un {
+			t.Errorf("Expected %s as source ident, got %s", un, ident)
+		}
+		if src.major != major {
+			t.Errorf("Expected %v as major version filter on gopkginSource, got %v", major, src.major)
+		}
+
+		// check that an expected rev is present
+		rev := evl[0].(PairedVersion).Underlying()
+		is, err := src.revisionPresentIn(rev)
+		if err != nil {
+			t.Errorf("Unexpected error while checking revision presence: %s", err)
+		} else if !is {
+			t.Errorf("Revision %s that should exist was not present", rev)
+		}
+
+		vlist, err := src.listVersions()
+		if err != nil {
+			t.Errorf("Unexpected error getting version pairs from hg repo: %s", err)
+		}
+
+		if src.ex.s&existsUpstream|existsInCache != existsUpstream|existsInCache {
+			t.Errorf("gopkginSource.listVersions() should have set the upstream and cache existence bits for search")
+		}
+		if src.ex.f&existsUpstream|existsInCache != existsUpstream|existsInCache {
+			t.Errorf("gopkginSource.listVersions() should have set the upstream and cache existence bits for found")
+		}
+
+		if len(vlist) != len(evl) {
+			t.Errorf("gopkgin test repo should've produced %v versions, got %v", len(evl), len(vlist))
+		} else {
+			SortForUpgrade(vlist)
+			if !reflect.DeepEqual(vlist, evl) {
+				t.Errorf("Version list was not what we expected:\n\t(GOT): %s\n\t(WNT): %s", vlist, evl)
+			}
+		}
+
+		// Run again, this time to ensure cache outputs correctly
+		vlist, err = src.listVersions()
+		if err != nil {
+			t.Errorf("Unexpected error getting version pairs from hg repo: %s", err)
+		}
+
+		if src.ex.s&existsUpstream|existsInCache != existsUpstream|existsInCache {
+			t.Errorf("gopkginSource.listVersions() should have set the upstream and cache existence bits for search")
+		}
+		if src.ex.f&existsUpstream|existsInCache != existsUpstream|existsInCache {
+			t.Errorf("gopkginSource.listVersions() should have set the upstream and cache existence bits for found")
+		}
+
+		if len(vlist) != len(evl) {
+			t.Errorf("gopkgin test repo should've produced %v versions, got %v", len(evl), len(vlist))
+		} else {
+			SortForUpgrade(vlist)
+			if !reflect.DeepEqual(vlist, evl) {
+				t.Errorf("Version list was not what we expected:\n\t(GOT): %s\n\t(WNT): %s", vlist, evl)
+			}
+		}
+
+		// recheck that rev is present, this time interacting with cache differently
+		is, err = src.revisionPresentIn(rev)
+		if err != nil {
+			t.Errorf("Unexpected error while re-checking revision presence: %s", err)
+		} else if !is {
+			t.Errorf("Revision that should exist was not present on re-check")
+		}
+	}
+
+	// simultaneously run for v1, v2, and v3 filters of the target repo
+	wg := &sync.WaitGroup{}
+	wg.Add(3)
+	go func() {
+		tfunc("github.com/sdboyer/gpkt", 1, []Version{
+			NewVersion("v1.1.0").Is(Revision("b2cb48dda625f6640b34d9ffb664533359ac8b91")),
+			NewVersion("v1.0.0").Is(Revision("bf85021c0405edbc4f3648b0603818d641674f72")),
+			newDefaultBranch("v1.1").Is(Revision("f1fbc520489a98306eb28c235204e39fa8a89c84")),
+			NewBranch("v1").Is(Revision("e3777f683305eafca223aefe56b4e8ecf103f467")),
+		})
+		wg.Done()
+	}()
+
+	go func() {
+		tfunc("github.com/sdboyer/gpkt", 2, []Version{
+			NewVersion("v2.0.0").Is(Revision("4a54adf81c75375d26d376459c00d5ff9b703e5e")),
+		})
+		wg.Done()
+	}()
+
+	go func() {
+		tfunc("github.com/sdboyer/gpkt", 3, []Version{
+			newDefaultBranch("v3").Is(Revision("4a54adf81c75375d26d376459c00d5ff9b703e5e")),
+		})
+		wg.Done()
+	}()
+
+	wg.Wait()
+	rf()
 }
 
 func TestBzrSourceInteractions(t *testing.T) {

--- a/source_test.go
+++ b/source_test.go
@@ -121,7 +121,7 @@ func TestGopkginSourceInteractions(t *testing.T) {
 		}
 	}
 
-	tfunc := func(n string, major int64, evl []Version) {
+	tfunc := func(opath, n string, major int64, evl []Version) {
 		un := "https://" + n
 		u, err := url.Parse(un)
 		if err != nil {
@@ -129,6 +129,7 @@ func TestGopkginSourceInteractions(t *testing.T) {
 			return
 		}
 		mb := maybeGopkginSource{
+			opath: opath,
 			url:   u,
 			major: major,
 		}
@@ -215,7 +216,7 @@ func TestGopkginSourceInteractions(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(3)
 	go func() {
-		tfunc("github.com/sdboyer/gpkt", 1, []Version{
+		tfunc("gopkg.in/sdboyer/gpkt.v1", "github.com/sdboyer/gpkt", 1, []Version{
 			NewVersion("v1.1.0").Is(Revision("b2cb48dda625f6640b34d9ffb664533359ac8b91")),
 			NewVersion("v1.0.0").Is(Revision("bf85021c0405edbc4f3648b0603818d641674f72")),
 			newDefaultBranch("v1.1").Is(Revision("f1fbc520489a98306eb28c235204e39fa8a89c84")),
@@ -225,14 +226,14 @@ func TestGopkginSourceInteractions(t *testing.T) {
 	}()
 
 	go func() {
-		tfunc("github.com/sdboyer/gpkt", 2, []Version{
+		tfunc("gopkg.in/sdboyer/gpkt.v2", "github.com/sdboyer/gpkt", 2, []Version{
 			NewVersion("v2.0.0").Is(Revision("4a54adf81c75375d26d376459c00d5ff9b703e5e")),
 		})
 		wg.Done()
 	}()
 
 	go func() {
-		tfunc("github.com/sdboyer/gpkt", 3, []Version{
+		tfunc("gopkg.in/sdboyer/gpkt.v3", "github.com/sdboyer/gpkt", 3, []Version{
 			newDefaultBranch("v3").Is(Revision("4a54adf81c75375d26d376459c00d5ff9b703e5e")),
 		})
 		wg.Done()

--- a/vcs_source.go
+++ b/vcs_source.go
@@ -13,15 +13,18 @@ import (
 	"github.com/termie/go-shutil"
 )
 
-type vcsSource interface {
-	syncLocal() error
-	ensureLocal() error
-	listLocalVersionPairs() ([]PairedVersion, sourceExistence, error)
-	listUpstreamVersionPairs() ([]PairedVersion, sourceExistence, error)
-	hasRevision(Revision) (bool, error)
-	checkout(Version) error
-	exportVersionTo(Version, string) error
-}
+// Kept here as a reference in case it does become important to implement a
+// vcsSource interface. Remove if/when it becomes clear we're never going to do
+// this.
+//type vcsSource interface {
+//syncLocal() error
+//ensureLocal() error
+//listLocalVersionPairs() ([]PairedVersion, sourceExistence, error)
+//listUpstreamVersionPairs() ([]PairedVersion, sourceExistence, error)
+//hasRevision(Revision) (bool, error)
+//checkout(Version) error
+//exportVersionTo(Version, string) error
+//}
 
 // gitSource is a generic git repository implementation that should work with
 // all standard git remotes.

--- a/vcs_source.go
+++ b/vcs_source.go
@@ -284,7 +284,7 @@ func (s *gopkginSource) listVersions() (vlist []Version, err error) {
 	}
 
 	// Apply gopkg.in's filtering rules
-	vlist := make([]Version, len(ovlist))
+	vlist = make([]Version, len(ovlist))
 	k := 0
 	var dbranch int // index of branch to be marked default
 	var bsv *semver.Version
@@ -300,7 +300,9 @@ func (s *gopkginSource) listVersions() (vlist []Version, err error) {
 		case branchVersion:
 			// The semver lib isn't exactly the same as gopkg.in's logic, but
 			// it's close enough that it's probably fine to use. We can be more
-			// exact if real problems crop up.
+			// exact if real problems crop up. The most obvious vector for
+			// problems is that we totally ignore the "unstable" designation
+			// right now.
 			sv, err := semver.NewVersion(tv.name)
 			if err != nil || sv.Major() != s.major {
 				// not a semver-shaped branch name at all, or not the same major
@@ -326,7 +328,11 @@ func (s *gopkginSource) listVersions() (vlist []Version, err error) {
 
 	vlist = vlist[:k]
 	if bsv != nil {
-		vlist[dbranch].(versionPair).v.(branchVersion).isDefault = true
+		dbv := vlist[dbranch].(versionPair)
+		vlist[dbranch] = branchVersion{
+			name:      dbv.v.(branchVersion).name,
+			isDefault: true,
+		}.Is(dbv.r)
 	}
 
 	// Process the filtered version data into the cache


### PR DESCRIPTION
Fixes #97 

This implementation isn't perfect - at minimum, we ignore the "unstable" suffix on import paths (because there's no clear semantic analogue) - but it's good enough for a first pass, I think.