### PR TITLE
Introduce 'requires'

### DIFF
--- a/solve_basic_test.go
+++ b/solve_basic_test.go
@@ -294,7 +294,7 @@ func mkrevlock(pairs ...string) fixLock {
 	return l
 }
 
-// mksolution makes creates a map of project identifiers to their LockedProject
+// mksolution creates a map of project identifiers to their LockedProject
 // result, which is sufficient to act as a solution fixture for the purposes of
 // most tests.
 //

--- a/solve_bimodal_test.go
+++ b/solve_bimodal_test.go
@@ -782,7 +782,7 @@ var bimodalFixtures = map[string]bimodalFixture{
 		r: mksolution(
 			"foo 1.0.0",
 			"bar 1.0.0",
-			mklp("baz 1.0.0", "baz/qux"),
+			mklp("baz 1.0.0", "qux"),
 		),
 	},
 	"require impossible subpackage": {
@@ -900,9 +900,13 @@ func (f bimodalFixture) rootmanifest() RootManifest {
 		tc:  pcSliceToMap(f.ds[0].devdeps),
 		ovr: f.ovr,
 		ig:  make(map[string]bool),
+		req: make(map[string]bool),
 	}
 	for _, ig := range f.ignore {
 		m.ig[ig] = true
+	}
+	for _, req := range f.require {
+		m.req[req] = true
 	}
 
 	return m

--- a/solve_bimodal_test.go
+++ b/solve_bimodal_test.go
@@ -800,7 +800,30 @@ var bimodalFixtures = map[string]bimodalFixture{
 		require: []string{"baz/qux"},
 		fail: &noVersionError{
 			pn: mkPI("baz"),
-			//fails: , // TODO new fail type for failed require
+			fails: []failedVersion{
+				{
+					v: NewVersion("2.0.0"),
+					f: &versionNotAllowedFailure{
+						goal:       mkAtom("baz 2.0.0"),
+						failparent: []dependency{mkDep("root", "baz 1.0.0", "baz/qux")},
+						c:          NewVersion("1.0.0"),
+					},
+				},
+				{
+					v: NewVersion("1.0.0"),
+					f: &checkeeHasProblemPackagesFailure{
+						goal: mkAtom("baz 1.0.0"),
+						failpkg: map[string]errDeppers{
+							"baz/qux": errDeppers{
+								err: nil, // nil indicates package is missing
+								deppers: []atom{
+									mkAtom("root"),
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	},
 	"require subpkg conflicts with other dep constraint": {
@@ -818,7 +841,30 @@ var bimodalFixtures = map[string]bimodalFixture{
 		require: []string{"baz/qux"},
 		fail: &noVersionError{
 			pn: mkPI("baz"),
-			//fails: , // TODO new fail type for failed require
+			fails: []failedVersion{
+				{
+					v: NewVersion("2.0.0"),
+					f: &versionNotAllowedFailure{
+						goal:       mkAtom("baz 2.0.0"),
+						failparent: []dependency{mkDep("foo 1.0.0", "baz 1.0.0", "baz")},
+						c:          NewVersion("1.0.0"),
+					},
+				},
+				{
+					v: NewVersion("1.0.0"),
+					f: &checkeeHasProblemPackagesFailure{
+						goal: mkAtom("baz 1.0.0"),
+						failpkg: map[string]errDeppers{
+							"baz/qux": errDeppers{
+								err: nil, // nil indicates package is missing
+								deppers: []atom{
+									mkAtom("root"),
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	},
 	"require independent subpkg conflicts with other dep constraint": {
@@ -836,7 +882,30 @@ var bimodalFixtures = map[string]bimodalFixture{
 		require: []string{"baz/qux"},
 		fail: &noVersionError{
 			pn: mkPI("baz"),
-			//fails: , // TODO new fail type for failed require
+			fails: []failedVersion{
+				{
+					v: NewVersion("2.0.0"),
+					f: &versionNotAllowedFailure{
+						goal:       mkAtom("baz 2.0.0"),
+						failparent: []dependency{mkDep("foo 1.0.0", "baz 1.0.0", "baz")},
+						c:          NewVersion("1.0.0"),
+					},
+				},
+				{
+					v: NewVersion("1.0.0"),
+					f: &checkeeHasProblemPackagesFailure{
+						goal: mkAtom("baz 1.0.0"),
+						failpkg: map[string]errDeppers{
+							"baz/qux": errDeppers{
+								err: nil, // nil indicates package is missing
+								deppers: []atom{
+									mkAtom("root"),
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	},
 }

--- a/solve_test.go
+++ b/solve_test.go
@@ -283,6 +283,8 @@ func TestRootLockNoVersionPairMatching(t *testing.T) {
 	fixtureSolveSimpleChecks(fix, res, err, t)
 }
 
+// TestBadSolveOpts exercises the different possible inputs to a solver that can
+// be determined as invalid in Prepare(), without any further work
 func TestBadSolveOpts(t *testing.T) {
 	pn := strconv.FormatInt(rand.Int63(), 36)
 	fix := basicFixtures["no dependencies"]
@@ -353,6 +355,28 @@ func TestBadSolveOpts(t *testing.T) {
 		t.Errorf("Should have errored on override with empty ProjectProperties")
 	} else if !strings.Contains(err.Error(), "foo, but without any non-zero properties") {
 		t.Error("Prepare should have given error override with empty ProjectProperties, but gave:", err)
+	}
+
+	params.Manifest = simpleRootManifest{
+		ig:  map[string]bool{"foo": true},
+		req: map[string]bool{"foo": true},
+	}
+	_, err = Prepare(params, sm)
+	if err == nil {
+		t.Errorf("Should have errored on pkg both ignored and required")
+	} else if !strings.Contains(err.Error(), "was given as both a required and ignored package") {
+		t.Error("Prepare should have given error with single ignore/require conflict error, but gave:", err)
+	}
+
+	params.Manifest = simpleRootManifest{
+		ig:  map[string]bool{"foo": true, "bar": true},
+		req: map[string]bool{"foo": true, "bar": true},
+	}
+	_, err = Prepare(params, sm)
+	if err == nil {
+		t.Errorf("Should have errored on pkg both ignored and required")
+	} else if !strings.Contains(err.Error(), "multiple packages given as both required and ignored: foo, bar") {
+		t.Error("Prepare should have given error with multiple ignore/require conflict error, but gave:", err)
 	}
 	params.Manifest = nil
 

--- a/solver.go
+++ b/solver.go
@@ -237,7 +237,7 @@ func Prepare(params SolveParameters, sm SourceManager) (Solver, error) {
 		case 1:
 			return nil, badOptsFailure(fmt.Sprintf("%q was given as both a required and ignored package", both[0]))
 		default:
-			return nil, badOptsFailure(fmt.Sprintf("multiple packages given as both required and ignored: %q", strings.Join(both, "\", \"")))
+			return nil, badOptsFailure(fmt.Sprintf("multiple packages given as both required and ignored: %s", strings.Join(both, ", ")))
 		}
 	}
 

--- a/solver.go
+++ b/solver.go
@@ -128,9 +128,11 @@ type solver struct {
 	// removal.
 	unsel *unselected
 
-	// Map of packages to ignore. Derived by converting SolveParameters.Ignore
-	// into a map during solver prep - which also, nicely, deduplicates it.
+	// Map of packages to ignore.
 	ig map[string]bool
+
+	// Map of packages to require.
+	req map[string]bool
 
 	// A stack of all the currently active versionQueues in the solver. The set
 	// of projects represented here corresponds closely to what's in s.sel,
@@ -216,9 +218,27 @@ func Prepare(params SolveParameters, sm SourceManager) (Solver, error) {
 	s := &solver{
 		params: params,
 		ig:     params.Manifest.IgnoredPackages(),
+		req:    params.Manifest.RequiredPackages(),
 		ovr:    params.Manifest.Overrides(),
 		tl:     params.TraceLogger,
 		rpt:    params.RootPackageTree.dup(),
+	}
+
+	if len(s.ig) != 0 {
+		var both []string
+		for pkg := range params.Manifest.RequiredPackages() {
+			if s.ig[pkg] {
+				both = append(both, pkg)
+			}
+		}
+		switch len(both) {
+		case 0:
+			break
+		case 1:
+			return nil, badOptsFailure(fmt.Sprintf("%q was given as both a required and ignored package", both[0]))
+		default:
+			return nil, badOptsFailure(fmt.Sprintf("multiple packages given as both required and ignored: %q", strings.Join(both, "\", \"")))
+		}
 	}
 
 	// Ensure the ignore and overrides maps are at least initialized
@@ -481,11 +501,7 @@ func (s *solver) selectRoot() error {
 	// If we're looking for root's deps, get it from opts and local root
 	// analysis, rather than having the sm do it
 	mdeps := s.ovr.overrideAll(s.rm.DependencyConstraints().merge(s.rm.TestDependencyConstraints()))
-
-	// Err is not possible at this point, as it could only come from
-	// listPackages(), which if we're here already succeeded for root
 	reach := s.rpt.ExternalReach(true, true, s.ig).ListExternalImports()
-
 	deps, err := s.intersectConstraintsWithImports(mdeps, reach)
 	if err != nil {
 		// TODO(sdboyer) this could well happen; handle it with a more graceful error
@@ -661,7 +677,7 @@ func (s *solver) createVersionQueue(bmi bimodalIdentifier) (*versionQueue, error
 			// Project exists only in vendor (and in some manifest somewhere)
 			// TODO(sdboyer) mark this for special handling, somehow?
 		} else {
-			return nil, fmt.Errorf("Project '%s' could not be located.", id)
+			return nil, fmt.Errorf("project '%s' could not be located", id)
 		}
 	}
 


### PR DESCRIPTION
This introduces the notion of a 'required' package: 

* Required packages must be present in any complete solution returned by the solver. 
* Requiring a package that is a logical child of the project root is not an error, but it is a no-op.
* Requiring and ignoring the same package from a manifest is an error.

This is a root-only capability: listing required packages is, thus, a `RootManifest` method.

- [x] Base type updates - interface and structs
- [x] Set of bimodal tests
- [x] `Prepare()` validation tests
- [x] Add/update fail types as needed
- [x] New logic in the solver itself
- [ ] Docs

Addresses #42 

