### PR TITLE
analyze: Fix up detection of // +build

### DIFF
--- a/_testdata/src/buildtag/invalid.go
+++ b/_testdata/src/buildtag/invalid.go
@@ -1,0 +1,13 @@
+// Hello
+// Not a valid +build ignore
+// No Really
+
+package buildtag
+
+import (
+	"sort"
+)
+
+var (
+	_ = sort.Strings
+)

--- a/analysis_test.go
+++ b/analysis_test.go
@@ -878,6 +878,25 @@ func TestListPackages(t *testing.T) {
 				},
 			},
 		},
+		"invalid buildtag like comments should be ignored": {
+			fileRoot:   j("buildtag"),
+			importRoot: "buildtag",
+			out: PackageTree{
+				ImportRoot: "buildtag",
+				Packages: map[string]PackageOrErr{
+					"buildtag": {
+						P: Package{
+							ImportPath:  "buildtag",
+							CommentPath: "",
+							Name:        "buildtag",
+							Imports: []string{
+								"sort",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for name, fix := range table {


### PR DESCRIPTION
Previously the included test package would have been ignored.

This ensures that the `// +build` is at the beginning of a line
before the package declaration.