### PR TITLE
Export non-git VCS correctly

### DIFF
--- a/result.go
+++ b/result.go
@@ -47,14 +47,6 @@ func WriteDepTree(basedir string, l Lock, sm SourceManager, sv bool) error {
 	for _, p := range l.Projects() {
 		to := filepath.FromSlash(filepath.Join(basedir, string(p.Ident().ProjectRoot)))
 
-		// Only make the parent dir, as some source implementations will balk on
-		// trying to write to an empty but existing dir.
-		//err := os.MkdirAll(filepath.Dir(to), 0777)
-		err := os.MkdirAll(to, 0777)
-		if err != nil {
-			return err
-		}
-
 		err = sm.ExportProject(p.Ident(), p.Version(), to)
 		if err != nil {
 			removeAll(basedir)

--- a/result.go
+++ b/result.go
@@ -3,7 +3,6 @@ package gps
 import (
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 )
 
@@ -46,9 +45,11 @@ func WriteDepTree(basedir string, l Lock, sm SourceManager, sv bool) error {
 
 	// TODO(sdboyer) parallelize
 	for _, p := range l.Projects() {
-		to := path.Join(basedir, string(p.Ident().ProjectRoot))
+		to := filepath.FromSlash(filepath.Join(basedir, string(p.Ident().ProjectRoot)))
 
-		err := os.MkdirAll(to, 0777)
+		// Only make the parent dir, as some source implementations will balk on
+		// trying to write to an empty but existing dir.
+		err := os.MkdirAll(filepath.Dir(to), 0777)
 		if err != nil {
 			return err
 		}

--- a/result.go
+++ b/result.go
@@ -49,7 +49,8 @@ func WriteDepTree(basedir string, l Lock, sm SourceManager, sv bool) error {
 
 		// Only make the parent dir, as some source implementations will balk on
 		// trying to write to an empty but existing dir.
-		err := os.MkdirAll(filepath.Dir(to), 0777)
+		//err := os.MkdirAll(filepath.Dir(to), 0777)
+		err := os.MkdirAll(to, 0777)
 		if err != nil {
 			return err
 		}

--- a/source.go
+++ b/source.go
@@ -432,5 +432,8 @@ func (bs *baseVCSSource) toRevOrErr(v Version) (r Revision, err error) {
 }
 
 func (bs *baseVCSSource) exportVersionTo(v Version, to string) error {
+	if err := bs.ensureCacheExistence(); err != nil {
+		return err
+	}
 	return bs.crepo.exportVersionTo(v, to)
 }

--- a/source.go
+++ b/source.go
@@ -2,6 +2,8 @@ package gps
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 )
 
@@ -435,5 +437,12 @@ func (bs *baseVCSSource) exportVersionTo(v Version, to string) error {
 	if err := bs.ensureCacheExistence(); err != nil {
 		return err
 	}
+
+	// Only make the parent dir, as the general implementation will balk on
+	// trying to write to an empty but existing dir.
+	if err := os.MkdirAll(filepath.Dir(to), 0777); err != nil {
+		return err
+	}
+
 	return bs.crepo.exportVersionTo(v, to)
 }

--- a/vcs_source.go
+++ b/vcs_source.go
@@ -40,6 +40,10 @@ func (s *gitSource) exportVersionTo(v Version, to string) error {
 		return err
 	}
 
+	if err := os.MkdirAll(to, 0777); err != nil {
+		return err
+	}
+
 	do := func() error {
 		s.crepo.mut.Lock()
 		defer s.crepo.mut.Unlock()


### PR DESCRIPTION
As raised in golang/dep#144, we weren't handling exports of bzr or hg repos correctly.