### PR TITLE
Monitored commands

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ dependencies:
   pre:
     - wget https://github.com/Masterminds/glide/releases/download/0.10.1/glide-0.10.1-linux-amd64.tar.gz
     - tar -vxz -C $HOME/bin --strip=1 -f glide-0.10.1-linux-amd64.tar.gz
-    - sudo apt-get install bzr
+    - sudo apt-get install bzr subversion
   override:
     - mkdir -p $HOME/.go_workspace/src
     - glide --home $HOME/.glide -y glide.yaml install --cache

--- a/cmd.go
+++ b/cmd.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os/exec"
 	"time"
+
+	"github.com/Masterminds/vcs"
 )
 
 // monitoredCmd wraps a cmd and will keep monitoring the process until it
@@ -96,4 +98,18 @@ type killCmdError struct {
 
 func (e killCmdError) Error() string {
 	return fmt.Sprintf("error killing command after timeout: %s", e.err)
+}
+
+func runFromCwd(cmd string, args ...string) ([]byte, error) {
+	c := newMonitoredCmd(exec.Command(cmd, args...), 2*time.Minute)
+	out, err := c.combinedOutput()
+	if err != nil {
+		err = fmt.Errorf("%s: %s", string(out), err)
+	}
+	return out, nil
+}
+
+func runFromRepoDir(repo vcs.Repo, cmd string, args ...string) ([]byte, error) {
+	c := newMonitoredCmd(repo.CmdFromDir(cmd, args...), 2*time.Minute)
+	return c.combinedOutput()
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,19 +1,10 @@
-hash: 2252a285ab27944a4d7adcba8dbd03980f59ba652f12db39fa93b927c345593e
-updated: 2016-06-06T22:10:37.696580463-04:00
+hash: ca4079cea0bcb746c052c89611d05eb5649440191bcad12afde0ac4c4a00fb97
+updated: 2017-03-09T21:12:59.686448539+01:00
 imports:
 - name: github.com/armon/go-radix
   version: 4239b77079c7b5d1243b7b4736304ce8ddb6f0f2
-- name: github.com/hashicorp/go-immutable-radix
-  version: 8e8ed81f8f0bf1bdd829593fdd5c29922c1ea990
-- name: github.com/hashicorp/golang-lru
-  version: a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
 - name: github.com/Masterminds/semver
   version: 94ad6eaf8457cf85a68c9b53fa42e9b1b8683783
-  vcs: git
 - name: github.com/Masterminds/vcs
   version: abd1ea7037d3652ef9833a164b627f49225e1131
-  vcs: git
-- name: github.com/termie/go-shutil
-  version: bcacb06fecaeec8dc42af03c87c6949f4a05c74c
-  vcs: git
-devImports: []
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,6 +3,8 @@ owners:
 - name: Sam Boyer
   email: tech@samboyer.org
 dependencies:
+- package: github.com/Masterminds/vcs
+  version: abd1ea7037d3652ef9833a164b627f49225e1131
 - package: github.com/Masterminds/semver
   branch: 2.x
 - package: github.com/termie/go-shutil

--- a/maybe_source.go
+++ b/maybe_source.go
@@ -75,7 +75,7 @@ func (m maybeGitSource) try(cachedir string, an ProjectAnalyzer) (source, string
 			an: an,
 			dc: newMetaCache(),
 			crepo: &repo{
-				r:     r,
+				r:     &gitRepo{r},
 				rpath: path,
 			},
 		},
@@ -121,7 +121,7 @@ func (m maybeGopkginSource) try(cachedir string, an ProjectAnalyzer) (source, st
 				an: an,
 				dc: newMetaCache(),
 				crepo: &repo{
-					r:     r,
+					r:     &gitRepo{r},
 					rpath: path,
 				},
 			},
@@ -164,7 +164,7 @@ func (m maybeBzrSource) try(cachedir string, an ProjectAnalyzer) (source, string
 				f: existsUpstream,
 			},
 			crepo: &repo{
-				r:     r,
+				r:     &bzrRepo{r},
 				rpath: path,
 			},
 		},
@@ -198,7 +198,7 @@ func (m maybeHgSource) try(cachedir string, an ProjectAnalyzer) (source, string,
 				f: existsUpstream,
 			},
 			crepo: &repo{
-				r:     r,
+				r:     &hgRepo{r},
 				rpath: path,
 			},
 		},

--- a/vcs_repo.go
+++ b/vcs_repo.go
@@ -28,18 +28,17 @@ func (r *gitRepo) Get() error {
 		if _, err := os.Stat(basePath); os.IsNotExist(err) {
 			err = os.MkdirAll(basePath, 0755)
 			if err != nil {
-				return vcs.NewLocalError("Unable to create directory", err, "")
+				return vcs.NewLocalError("unable to create directory", err, "")
 			}
 
 			out, err = runFromCwd("git", "clone", r.Remote(), r.LocalPath())
 			if err != nil {
-				return vcs.NewRemoteError("Unable to get repository", err, string(out))
+				return vcs.NewRemoteError("unable to get repository", err, string(out))
 			}
 			return err
 		}
-
 	} else if err != nil {
-		return vcs.NewRemoteError("Unable to get repository", err, string(out))
+		return vcs.NewRemoteError("unable to get repository", err, string(out))
 	}
 
 	return nil
@@ -49,14 +48,14 @@ func (r *gitRepo) Update() error {
 	// Perform a fetch to make sure everything is up to date.
 	out, err := runFromRepoDir(r, "git", "fetch", "--tags", r.RemoteLocation)
 	if err != nil {
-		return vcs.NewRemoteError("Unable to update repository", err, string(out))
+		return vcs.NewRemoteError("unable to update repository", err, string(out))
 	}
 
 	// When in a detached head state, such as when an individual commit is checked
 	// out do not attempt a pull. It will cause an error.
 	detached, err := r.isDetachedHead()
 	if err != nil {
-		return vcs.NewLocalError("Unable to update repository", err, "")
+		return vcs.NewLocalError("unable to update repository", err, "")
 	}
 
 	if detached {
@@ -65,7 +64,7 @@ func (r *gitRepo) Update() error {
 
 	out, err = runFromRepoDir(r, "git", "pull")
 	if err != nil {
-		return vcs.NewRemoteError("Unable to update repository", err, string(out))
+		return vcs.NewRemoteError("unable to update repository", err, string(out))
 	}
 
 	return r.defendAgainstSubmodules()
@@ -77,18 +76,20 @@ func (r *gitRepo) defendAgainstSubmodules() error {
 	// First, update them to whatever they should be, if there should happen to be any.
 	out, err := runFromRepoDir(r, "git", "submodule", "update", "--init", "--recursive")
 	if err != nil {
-		return vcs.NewLocalError("Unexpected error while defensively updating submodules", err, string(out))
+		return vcs.NewLocalError("unexpected error while defensively updating submodules", err, string(out))
 	}
+
 	// Now, do a special extra-aggressive clean in case changing versions caused
 	// one or more submodules to go away.
 	out, err = runFromRepoDir(r, "git", "clean", "-x", "-d", "-f", "-f")
 	if err != nil {
-		return vcs.NewLocalError("Unexpected error while defensively cleaning up after possible derelict submodule directories", err, string(out))
+		return vcs.NewLocalError("unexpected error while defensively cleaning up after possible derelict submodule directories", err, string(out))
 	}
+
 	// Then, repeat just in case there are any nested submodules that went away.
 	out, err = runFromRepoDir(r, "git", "submodule", "foreach", "--recursive", "git", "clean", "-x", "-d", "-f", "-f")
 	if err != nil {
-		return vcs.NewLocalError("Unexpected error while defensively cleaning up after possible derelict nested submodule directories", err, string(out))
+		return vcs.NewLocalError("unexpected error while defensively cleaning up after possible derelict nested submodule directories", err, string(out))
 	}
 
 	return nil
@@ -137,13 +138,13 @@ func (r *bzrRepo) Get() error {
 	if _, err := os.Stat(basePath); os.IsNotExist(err) {
 		err = os.MkdirAll(basePath, 0755)
 		if err != nil {
-			return vcs.NewLocalError("Unable to create directory", err, "")
+			return vcs.NewLocalError("unable to create directory", err, "")
 		}
 	}
 
 	out, err := runFromCwd("bzr", "branch", r.Remote(), r.LocalPath())
 	if err != nil {
-		return vcs.NewRemoteError("Unable to get repository", err, string(out))
+		return vcs.NewRemoteError("unable to get repository", err, string(out))
 	}
 
 	return nil
@@ -152,12 +153,14 @@ func (r *bzrRepo) Get() error {
 func (r *bzrRepo) Update() error {
 	out, err := runFromRepoDir(r, "bzr", "pull")
 	if err != nil {
-		return vcs.NewRemoteError("Unable to update repository", err, string(out))
+		return vcs.NewRemoteError("unable to update repository", err, string(out))
 	}
+
 	out, err = runFromRepoDir(r, "bzr", "update")
 	if err != nil {
-		return vcs.NewRemoteError("Unable to update repository", err, string(out))
+		return vcs.NewRemoteError("unable to update repository", err, string(out))
 	}
+
 	return nil
 }
 
@@ -168,7 +171,7 @@ type hgRepo struct {
 func (r *hgRepo) Get() error {
 	out, err := runFromCwd("hg", "clone", r.Remote(), r.LocalPath())
 	if err != nil {
-		return vcs.NewRemoteError("Unable to get repository", err, string(out))
+		return vcs.NewRemoteError("unable to get repository", err, string(out))
 	}
 
 	return nil
@@ -181,7 +184,7 @@ func (r *hgRepo) Update() error {
 func (r *hgRepo) UpdateVersion(version string) error {
 	out, err := runFromRepoDir(r, "hg", "pull")
 	if err != nil {
-		return vcs.NewRemoteError("Unable to update checked out version", err, string(out))
+		return vcs.NewRemoteError("unable to update checked out version", err, string(out))
 	}
 
 	if len(strings.TrimSpace(version)) > 0 {
@@ -191,7 +194,7 @@ func (r *hgRepo) UpdateVersion(version string) error {
 	}
 
 	if err != nil {
-		return vcs.NewRemoteError("Unable to update checked out version", err, string(out))
+		return vcs.NewRemoteError("unable to update checked out version", err, string(out))
 	}
 
 	return nil
@@ -208,26 +211,30 @@ func (r *svnRepo) Get() error {
 	} else if runtime.GOOS == "windows" && filepath.VolumeName(remote) != "" {
 		remote = "file:///" + remote
 	}
+
 	out, err := runFromCwd("svn", "checkout", remote, r.LocalPath())
 	if err != nil {
-		return vcs.NewRemoteError("Unable to get repository", err, string(out))
+		return vcs.NewRemoteError("unable to get repository", err, string(out))
 	}
+
 	return nil
 }
 
 func (r *svnRepo) Update() error {
 	out, err := runFromRepoDir(r, "svn", "update")
 	if err != nil {
-		return vcs.NewRemoteError("Unable to update repository", err, string(out))
+		return vcs.NewRemoteError("unable to update repository", err, string(out))
 	}
+
 	return err
 }
 
 func (r *svnRepo) UpdateVersion(version string) error {
 	out, err := runFromRepoDir(r, "svn", "update", "-r", version)
 	if err != nil {
-		return vcs.NewRemoteError("Unable to update checked out version", err, string(out))
+		return vcs.NewRemoteError("unable to update checked out version", err, string(out))
 	}
+
 	return nil
 }
 
@@ -236,21 +243,23 @@ func (r *svnRepo) CommitInfo(id string) (*vcs.CommitInfo, error) {
 	// svn info does provide details for these but does not have elements like
 	// the commit message.
 	if id == "HEAD" || id == "BASE" {
-		type Commit struct {
+		type commit struct {
 			Revision string `xml:"revision,attr"`
 		}
-		type Info struct {
-			Commit Commit `xml:"entry>commit"`
+
+		type info struct {
+			Commit commit `xml:"entry>commit"`
 		}
 
 		out, err := runFromRepoDir(r, "svn", "info", "-r", id, "--xml")
 		if err != nil {
-			return nil, vcs.NewLocalError("Unable to retrieve commit information", err, string(out))
+			return nil, vcs.NewLocalError("unable to retrieve commit information", err, string(out))
 		}
-		infos := &Info{}
+
+		infos := new(info)
 		err = xml.Unmarshal(out, &infos)
 		if err != nil {
-			return nil, vcs.NewLocalError("Unable to retrieve commit information", err, string(out))
+			return nil, vcs.NewLocalError("unable to retrieve commit information", err, string(out))
 		}
 
 		id = infos.Commit.Revision
@@ -261,24 +270,26 @@ func (r *svnRepo) CommitInfo(id string) (*vcs.CommitInfo, error) {
 
 	out, err := runFromRepoDir(r, "svn", "log", "-r", id, "--xml")
 	if err != nil {
-		return nil, vcs.NewRemoteError("Unable to retrieve commit information", err, string(out))
+		return nil, vcs.NewRemoteError("unable to retrieve commit information", err, string(out))
 	}
 
-	type Logentry struct {
+	type logentry struct {
 		Author string `xml:"author"`
 		Date   string `xml:"date"`
 		Msg    string `xml:"msg"`
 	}
-	type Log struct {
+
+	type log struct {
 		XMLName xml.Name   `xml:"log"`
-		Logs    []Logentry `xml:"logentry"`
+		Logs    []logentry `xml:"logentry"`
 	}
 
-	logs := &Log{}
+	logs := new(log)
 	err = xml.Unmarshal(out, &logs)
 	if err != nil {
-		return nil, vcs.NewLocalError("Unable to retrieve commit information", err, string(out))
+		return nil, vcs.NewLocalError("unable to retrieve commit information", err, string(out))
 	}
+
 	if len(logs.Logs) == 0 {
 		return nil, vcs.ErrRevisionUnavailable
 	}
@@ -292,7 +303,7 @@ func (r *svnRepo) CommitInfo(id string) (*vcs.CommitInfo, error) {
 	if len(logs.Logs[0].Date) > 0 {
 		ci.Date, err = time.Parse(time.RFC3339Nano, logs.Logs[0].Date)
 		if err != nil {
-			return nil, vcs.NewLocalError("Unable to retrieve commit information", err, string(out))
+			return nil, vcs.NewLocalError("unable to retrieve commit information", err, string(out))
 		}
 	}
 

--- a/vcs_repo.go
+++ b/vcs_repo.go
@@ -13,6 +13,9 @@ import (
 	"github.com/Masterminds/vcs"
 )
 
+// original implementation of these methods come from
+// https://github.com/Masterminds/vcs
+
 type gitRepo struct {
 	*vcs.GitRepo
 }

--- a/vcs_repo.go
+++ b/vcs_repo.go
@@ -1,0 +1,300 @@
+package gps
+
+import (
+	"bytes"
+	"encoding/xml"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/Masterminds/vcs"
+)
+
+type gitRepo struct {
+	*vcs.GitRepo
+}
+
+func (r *gitRepo) Get() error {
+	out, err := runFromCwd("git", "clone", "--recursive", r.Remote(), r.LocalPath())
+
+	// There are some windows cases where Git cannot create the parent directory,
+	// if it does not already exist, to the location it's trying to create the
+	// repo. Catch that error and try to handle it.
+	if err != nil && r.isUnableToCreateDir(err) {
+		basePath := filepath.Dir(filepath.FromSlash(r.LocalPath()))
+		if _, err := os.Stat(basePath); os.IsNotExist(err) {
+			err = os.MkdirAll(basePath, 0755)
+			if err != nil {
+				return vcs.NewLocalError("Unable to create directory", err, "")
+			}
+
+			out, err = runFromCwd("git", "clone", r.Remote(), r.LocalPath())
+			if err != nil {
+				return vcs.NewRemoteError("Unable to get repository", err, string(out))
+			}
+			return err
+		}
+
+	} else if err != nil {
+		return vcs.NewRemoteError("Unable to get repository", err, string(out))
+	}
+
+	return nil
+}
+
+func (r *gitRepo) Update() error {
+	// Perform a fetch to make sure everything is up to date.
+	out, err := runFromRepoDir(r, "git", "fetch", "--tags", r.RemoteLocation)
+	if err != nil {
+		return vcs.NewRemoteError("Unable to update repository", err, string(out))
+	}
+
+	// When in a detached head state, such as when an individual commit is checked
+	// out do not attempt a pull. It will cause an error.
+	detached, err := r.isDetachedHead()
+	if err != nil {
+		return vcs.NewLocalError("Unable to update repository", err, "")
+	}
+
+	if detached {
+		return nil
+	}
+
+	out, err = runFromRepoDir(r, "git", "pull")
+	if err != nil {
+		return vcs.NewRemoteError("Unable to update repository", err, string(out))
+	}
+
+	return r.defendAgainstSubmodules()
+}
+
+// defendAgainstSubmodules tries to keep repo state sane in the event of
+// submodules. Or nested submodules. What a great idea, submodules.
+func (r *gitRepo) defendAgainstSubmodules() error {
+	// First, update them to whatever they should be, if there should happen to be any.
+	out, err := runFromRepoDir(r, "git", "submodule", "update", "--init", "--recursive")
+	if err != nil {
+		return vcs.NewLocalError("Unexpected error while defensively updating submodules", err, string(out))
+	}
+	// Now, do a special extra-aggressive clean in case changing versions caused
+	// one or more submodules to go away.
+	out, err = runFromRepoDir(r, "git", "clean", "-x", "-d", "-f", "-f")
+	if err != nil {
+		return vcs.NewLocalError("Unexpected error while defensively cleaning up after possible derelict submodule directories", err, string(out))
+	}
+	// Then, repeat just in case there are any nested submodules that went away.
+	out, err = runFromRepoDir(r, "git", "submodule", "foreach", "--recursive", "git", "clean", "-x", "-d", "-f", "-f")
+	if err != nil {
+		return vcs.NewLocalError("Unexpected error while defensively cleaning up after possible derelict nested submodule directories", err, string(out))
+	}
+
+	return nil
+}
+
+// isUnableToCreateDir checks for an error in the command to see if an error
+// where the parent directory of the VCS local path doesn't exist. This is
+// done in a multi-lingual manner.
+func (r *gitRepo) isUnableToCreateDir(err error) bool {
+	msg := err.Error()
+	if strings.HasPrefix(msg, "could not create work tree dir") ||
+		strings.HasPrefix(msg, "不能创建工作区目录") ||
+		strings.HasPrefix(msg, "no s'ha pogut crear el directori d'arbre de treball") ||
+		strings.HasPrefix(msg, "impossible de créer le répertoire de la copie de travail") ||
+		strings.HasPrefix(msg, "kunde inte skapa arbetskatalogen") ||
+		(strings.HasPrefix(msg, "Konnte Arbeitsverzeichnis") && strings.Contains(msg, "nicht erstellen")) ||
+		(strings.HasPrefix(msg, "작업 디렉터리를") && strings.Contains(msg, "만들 수 없습니다")) {
+		return true
+	}
+
+	return false
+}
+
+// isDetachedHead will detect if git repo is in "detached head" state.
+func (r *gitRepo) isDetachedHead() (bool, error) {
+	p := filepath.Join(r.LocalPath(), ".git", "HEAD")
+	contents, err := ioutil.ReadFile(p)
+	if err != nil {
+		return false, err
+	}
+
+	contents = bytes.TrimSpace(contents)
+	if bytes.HasPrefix(contents, []byte("ref: ")) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+type bzrRepo struct {
+	*vcs.BzrRepo
+}
+
+func (r *bzrRepo) Get() error {
+	basePath := filepath.Dir(filepath.FromSlash(r.LocalPath()))
+	if _, err := os.Stat(basePath); os.IsNotExist(err) {
+		err = os.MkdirAll(basePath, 0755)
+		if err != nil {
+			return vcs.NewLocalError("Unable to create directory", err, "")
+		}
+	}
+
+	out, err := runFromCwd("bzr", "branch", r.Remote(), r.LocalPath())
+	if err != nil {
+		return vcs.NewRemoteError("Unable to get repository", err, string(out))
+	}
+
+	return nil
+}
+
+func (r *bzrRepo) Update() error {
+	out, err := runFromRepoDir(r, "bzr", "pull")
+	if err != nil {
+		return vcs.NewRemoteError("Unable to update repository", err, string(out))
+	}
+	out, err = runFromRepoDir(r, "bzr", "update")
+	if err != nil {
+		return vcs.NewRemoteError("Unable to update repository", err, string(out))
+	}
+	return nil
+}
+
+type hgRepo struct {
+	*vcs.HgRepo
+}
+
+func (r *hgRepo) Get() error {
+	out, err := runFromCwd("hg", "clone", r.Remote(), r.LocalPath())
+	if err != nil {
+		return vcs.NewRemoteError("Unable to get repository", err, string(out))
+	}
+
+	return nil
+}
+
+func (r *hgRepo) Update() error {
+	return r.UpdateVersion(``)
+}
+
+func (r *hgRepo) UpdateVersion(version string) error {
+	out, err := runFromRepoDir(r, "hg", "pull")
+	if err != nil {
+		return vcs.NewRemoteError("Unable to update checked out version", err, string(out))
+	}
+
+	if len(strings.TrimSpace(version)) > 0 {
+		out, err = runFromRepoDir(r, "hg", "update", version)
+	} else {
+		out, err = runFromRepoDir(r, "hg", "update")
+	}
+
+	if err != nil {
+		return vcs.NewRemoteError("Unable to update checked out version", err, string(out))
+	}
+
+	return nil
+}
+
+type svnRepo struct {
+	*vcs.SvnRepo
+}
+
+func (r *svnRepo) Get() error {
+	remote := r.Remote()
+	if strings.HasPrefix(remote, "/") {
+		remote = "file://" + remote
+	} else if runtime.GOOS == "windows" && filepath.VolumeName(remote) != "" {
+		remote = "file:///" + remote
+	}
+	out, err := runFromCwd("svn", "checkout", remote, r.LocalPath())
+	if err != nil {
+		return vcs.NewRemoteError("Unable to get repository", err, string(out))
+	}
+	return nil
+}
+
+func (r *svnRepo) Update() error {
+	out, err := runFromRepoDir(r, "svn", "update")
+	if err != nil {
+		return vcs.NewRemoteError("Unable to update repository", err, string(out))
+	}
+	return err
+}
+
+func (r *svnRepo) UpdateVersion(version string) error {
+	out, err := runFromRepoDir(r, "svn", "update", "-r", version)
+	if err != nil {
+		return vcs.NewRemoteError("Unable to update checked out version", err, string(out))
+	}
+	return nil
+}
+
+func (r *svnRepo) CommitInfo(id string) (*vcs.CommitInfo, error) {
+	// There are cases where Svn log doesn't return anything for HEAD or BASE.
+	// svn info does provide details for these but does not have elements like
+	// the commit message.
+	if id == "HEAD" || id == "BASE" {
+		type Commit struct {
+			Revision string `xml:"revision,attr"`
+		}
+		type Info struct {
+			Commit Commit `xml:"entry>commit"`
+		}
+
+		out, err := runFromRepoDir(r, "svn", "info", "-r", id, "--xml")
+		if err != nil {
+			return nil, vcs.NewLocalError("Unable to retrieve commit information", err, string(out))
+		}
+		infos := &Info{}
+		err = xml.Unmarshal(out, &infos)
+		if err != nil {
+			return nil, vcs.NewLocalError("Unable to retrieve commit information", err, string(out))
+		}
+
+		id = infos.Commit.Revision
+		if id == "" {
+			return nil, vcs.ErrRevisionUnavailable
+		}
+	}
+
+	out, err := runFromRepoDir(r, "svn", "log", "-r", id, "--xml")
+	if err != nil {
+		return nil, vcs.NewRemoteError("Unable to retrieve commit information", err, string(out))
+	}
+
+	type Logentry struct {
+		Author string `xml:"author"`
+		Date   string `xml:"date"`
+		Msg    string `xml:"msg"`
+	}
+	type Log struct {
+		XMLName xml.Name   `xml:"log"`
+		Logs    []Logentry `xml:"logentry"`
+	}
+
+	logs := &Log{}
+	err = xml.Unmarshal(out, &logs)
+	if err != nil {
+		return nil, vcs.NewLocalError("Unable to retrieve commit information", err, string(out))
+	}
+	if len(logs.Logs) == 0 {
+		return nil, vcs.ErrRevisionUnavailable
+	}
+
+	ci := &vcs.CommitInfo{
+		Commit:  id,
+		Author:  logs.Logs[0].Author,
+		Message: logs.Logs[0].Msg,
+	}
+
+	if len(logs.Logs[0].Date) > 0 {
+		ci.Date, err = time.Parse(time.RFC3339Nano, logs.Logs[0].Date)
+		if err != nil {
+			return nil, vcs.NewLocalError("Unable to retrieve commit information", err, string(out))
+		}
+	}
+
+	return ci, nil
+}

--- a/vcs_repo_test.go
+++ b/vcs_repo_test.go
@@ -1,0 +1,292 @@
+package gps
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Masterminds/vcs"
+)
+
+// original implementation of these test files come from
+// https://github.com/Masterminds/vcs test files
+
+func TestSvnRepo(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "go-vcs-svn-tests")
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err = os.RemoveAll(tempDir)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	rep, err := vcs.NewSvnRepo("https://github.com/Masterminds/VCSTestRepo/trunk", tempDir+string(os.PathSeparator)+"VCSTestRepo")
+	if err != nil {
+		t.Error(err)
+	}
+	repo := &svnRepo{rep}
+
+	// Do an initial checkout.
+	err = repo.Get()
+	if err != nil {
+		t.Errorf("Unable to checkout SVN repo. Err was %s", err)
+	}
+
+	// Verify SVN repo is a SVN repo
+	if !repo.CheckLocal() {
+		t.Error("Problem checking out repo or SVN CheckLocal is not working")
+	}
+
+	// Update the version to a previous version.
+	err = repo.UpdateVersion("r2")
+	if err != nil {
+		t.Errorf("Unable to update SVN repo version. Err was %s", err)
+	}
+
+	// Use Version to verify we are on the right version.
+	v, err := repo.Version()
+	if v != "2" {
+		t.Error("Error checking checked SVN out version")
+	}
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Perform an update which should take up back to the latest version.
+	err = repo.Update()
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Make sure we are on a newer version because of the update.
+	v, err = repo.Version()
+	if v == "2" {
+		t.Error("Error with version. Still on old version. Update failed")
+	}
+	if err != nil {
+		t.Error(err)
+	}
+
+	ci, err := repo.CommitInfo("2")
+	if err != nil {
+		t.Error(err)
+	}
+	if ci.Commit != "2" {
+		t.Error("Svn.CommitInfo wrong commit id")
+	}
+	if ci.Author != "matt.farina" {
+		t.Error("Svn.CommitInfo wrong author")
+	}
+	if ci.Message != "Update README.md" {
+		t.Error("Svn.CommitInfo wrong message")
+	}
+	ti, err := time.Parse(time.RFC3339Nano, "2015-07-29T13:46:20.000000Z")
+	if err != nil {
+		t.Error(err)
+	}
+	if !ti.Equal(ci.Date) {
+		t.Error("Svn.CommitInfo wrong date")
+	}
+
+	_, err = repo.CommitInfo("555555555")
+	if err != vcs.ErrRevisionUnavailable {
+		t.Error("Svn didn't return expected ErrRevisionUnavailable")
+	}
+}
+
+func TestHgRepo(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "go-vcs-hg-tests")
+	if err != nil {
+		t.Error(err)
+	}
+
+	defer func() {
+		err = os.RemoveAll(tempDir)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	rep, err := vcs.NewHgRepo("https://bitbucket.org/mattfarina/testhgrepo", tempDir+"/testhgrepo")
+	if err != nil {
+		t.Error(err)
+	}
+
+	repo := &hgRepo{rep}
+
+	// Do an initial clone.
+	err = repo.Get()
+	if err != nil {
+		t.Errorf("Unable to clone Hg repo. Err was %s", err)
+	}
+
+	// Verify Hg repo is a Hg repo
+	if !repo.CheckLocal() {
+		t.Error("Problem checking out repo or Hg CheckLocal is not working")
+	}
+
+	// Set the version using the short hash.
+	err = repo.UpdateVersion("a5494ba2177f")
+	if err != nil {
+		t.Errorf("Unable to update Hg repo version. Err was %s", err)
+	}
+
+	// Use Version to verify we are on the right version.
+	v, err := repo.Version()
+	if v != "a5494ba2177ff9ef26feb3c155dfecc350b1a8ef" {
+		t.Errorf("Error checking checked out Hg version: %s", v)
+	}
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Perform an update.
+	err = repo.Update()
+	if err != nil {
+		t.Error(err)
+	}
+
+	v, err = repo.Version()
+	if v != "9c6ccbca73e8a1351c834f33f57f1f7a0329ad35" {
+		t.Errorf("Error checking checked out Hg version: %s", v)
+	}
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestGitRepo(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "go-vcs-git-tests")
+	if err != nil {
+		t.Error(err)
+	}
+
+	defer func() {
+		err = os.RemoveAll(tempDir)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	rep, err := vcs.NewGitRepo("https://github.com/Masterminds/VCSTestRepo", tempDir+"/VCSTestRepo")
+	if err != nil {
+		t.Error(err)
+	}
+
+	repo := &gitRepo{rep}
+
+	// Do an initial clone.
+	err = repo.Get()
+	if err != nil {
+		t.Errorf("Unable to clone Git repo. Err was %s", err)
+	}
+
+	// Verify Git repo is a Git repo
+	if !repo.CheckLocal() {
+		t.Error("Problem checking out repo or Git CheckLocal is not working")
+	}
+
+	// Perform an update.
+	err = repo.Update()
+	if err != nil {
+		t.Error(err)
+	}
+
+	v, err := repo.Current()
+	if err != nil {
+		t.Errorf("Error trying Git Current: %s", err)
+	}
+	if v != "master" {
+		t.Errorf("Current failed to detect Git on tip of master. Got version: %s", v)
+	}
+
+	// Set the version using the short hash.
+	err = repo.UpdateVersion("806b07b")
+	if err != nil {
+		t.Errorf("Unable to update Git repo version. Err was %s", err)
+	}
+
+	// Once a ref has been checked out the repo is in a detached head state.
+	// Trying to pull in an update in this state will cause an error. Update
+	// should cleanly handle this. Pulling on a branch (tested elsewhere) and
+	// skipping that here.
+	err = repo.Update()
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Use Version to verify we are on the right version.
+	v, err = repo.Version()
+	if v != "806b07b08faa21cfbdae93027904f80174679402" {
+		t.Error("Error checking checked out Git version")
+	}
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestBzrRepo(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "go-vcs-bzr-tests")
+	if err != nil {
+		t.Error(err)
+	}
+
+	defer func() {
+		err = os.RemoveAll(tempDir)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	rep, err := vcs.NewBzrRepo("https://launchpad.net/govcstestbzrrepo", tempDir+"/govcstestbzrrepo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := &bzrRepo{rep}
+
+	// Do an initial clone.
+	err = repo.Get()
+	if err != nil {
+		t.Errorf("Unable to clone Bzr repo. Err was %s", err)
+	}
+
+	// Verify Bzr repo is a Bzr repo
+	if !repo.CheckLocal() {
+		t.Error("Problem checking out repo or Bzr CheckLocal is not working")
+	}
+
+	v, err := repo.Current()
+	if err != nil {
+		t.Errorf("Error trying Bzr Current: %s", err)
+	}
+	if v != "-1" {
+		t.Errorf("Current failed to detect Bzr on tip of branch. Got version: %s", v)
+	}
+
+	err = repo.UpdateVersion("2")
+	if err != nil {
+		t.Errorf("Unable to update Bzr repo version. Err was %s", err)
+	}
+
+	// Use Version to verify we are on the right version.
+	v, err = repo.Version()
+	if v != "2" {
+		t.Error("Error checking checked out Bzr version")
+	}
+	if err != nil {
+		t.Error(err)
+	}
+
+	v, err = repo.Current()
+	if err != nil {
+		t.Errorf("Error trying Bzr Current: %s", err)
+	}
+	if v != "2" {
+		t.Errorf("Current failed to detect Bzr on rev 2 of branch. Got version: %s", v)
+	}
+}


### PR DESCRIPTION
As discussed in #84, I'll be working on this WIP so you can see if the direction this is going is where you want it to @sdboyer 

The cleaner way to do this, imho, was to wrap each different `vcs.Repo` implementation that is a `vcs.Repo` itself too, so we don't have to reimplement anything. In practice, it has ended up in a lot of copied code from vcs because of not exported code and so on.

I've only implemented the wrapper for git repos so far, so tell me if you want me to keep on this path or do something else entirely. 
