### PR TITLE
Dep needs to respect flat packages

### DIFF
--- a/trace.go
+++ b/trace.go
@@ -97,9 +97,9 @@ func (s *solver) traceFinish(sol solution, err error) {
 		for _, lp := range sol.Projects() {
 			pkgcount += len(lp.pkgs)
 		}
-		s.tl.Printf("%s%s found solution with %v packages from %v projects", innerIndent, successChar, pkgcount, len(sol.Projects()))
+		s.tl.Printf("(0) %s%s found solution with %v packages from %v projects", innerIndent, successChar, pkgcount, len(sol.Projects()))
 	} else {
-		s.tl.Printf("%s%s solving failed", innerIndent, failChar)
+		s.tl.Printf("(0) %s%s solving failed", innerIndent, failChar)
 	}
 }
 


### PR DESCRIPTION
Right now dep was trying to find versions for a bmi if it was a root level package.. This PR bypasses the BMI in this case so we don't fail trying to check on ourselves

Closes https://github.com/golang/dep/issues/270

Also fixes indentation in tracer
