### PR TITLE
Fix err shadowing bug that caused panics for unreachable repos

### DIFF
--- a/deduce.go
+++ b/deduce.go
@@ -655,7 +655,7 @@ func (sm *SourceMgr) deduceFromPath(path string) (deductionFuture, error) {
 			defer close(c)
 			// make sure the metadata future is finished (without errors), thus
 			// guaranteeing that ru and vcs will be populated
-			_, err := root()
+			_, err = root()
 			if err != nil {
 				return
 			}
@@ -683,7 +683,6 @@ func (sm *SourceMgr) deduceFromPath(path string) (deductionFuture, error) {
 			return src, ident, err
 		}
 	}
-
 	return deductionFuture{
 		rslow: true,
 		root:  root,

--- a/manager_test.go
+++ b/manager_test.go
@@ -850,3 +850,17 @@ func TestSignalHandling(t *testing.T) {
 	}
 	clean()
 }
+
+func TestUnreachableSource(t *testing.T) {
+	// If a git remote is unreachable (maybe the server is only accessible behind a VPN, or
+	// something), we should return a clear error, not a panic.
+
+	sm, clean := mkNaiveSM(t)
+	defer clean()
+
+	id := mkPI("golang.org/notareal/repo").normalize()
+	_, err := sm.ListVersions(id)
+	if err == nil {
+		t.Error("expected err when listing versions of a bogus source, but got nil")
+	}
+}


### PR DESCRIPTION
This was a little tricky: my company has a private git server hidden behind a VPN. I ran `dep status` while _not_ on the VPN, and `dep` panicked and crashed when it tried to look up the version of one of those private repos. This seemed weird!

It turns out this comes down to an error shadowing bug, deep in the *SourceMgr's futures. The test here panics on master, but passes with this revision.