### PR TITLE
Relax rules for valid github usernames

### DIFF
--- a/deduce.go
+++ b/deduce.go
@@ -48,10 +48,9 @@ func validateVCSScheme(scheme, typ string) bool {
 
 // Regexes for the different known import path flavors
 var (
-	// This regex allowed some usernames that github currently disallows. They
-	// may have allowed them in the past; keeping it in case we need to revert.
-	//ghRegex      = regexp.MustCompile(`^(?P<root>github\.com/([A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+))(/[A-Za-z0-9_.\-]+)*$`)
-	ghRegex      = regexp.MustCompile(`^(?P<root>github\.com(/[A-Za-z0-9][-A-Za-z0-9]*[A-Za-z0-9]/[A-Za-z0-9_.\-]+))((?:/[A-Za-z0-9_.\-]+)*)$`)
+	// This regex allows some usernames that github currently disallows. They
+	// have allowed them in the past.
+	ghRegex      = regexp.MustCompile(`^(?P<root>github\.com(/[A-Za-z0-9][-A-Za-z0-9]*/[A-Za-z0-9_.\-]+))((?:/[A-Za-z0-9_.\-]+)*)$`)
 	gpinNewRegex = regexp.MustCompile(`^(?P<root>gopkg\.in(?:(/[a-zA-Z0-9][-a-zA-Z0-9]+)?)(/[a-zA-Z][-.a-zA-Z0-9]*)\.((?:v0|v[1-9][0-9]*)(?:\.0|\.[1-9][0-9]*){0,2}(?:-unstable)?)(?:\.git)?)((?:/[a-zA-Z0-9][-.a-zA-Z0-9]*)*)$`)
 	//gpinOldRegex = regexp.MustCompile(`^(?P<root>gopkg\.in/(?:([a-z0-9][-a-z0-9]+)/)?((?:v0|v[1-9][0-9]*)(?:\.0|\.[1-9][0-9]*){0,2}(-unstable)?)/([a-zA-Z][-a-zA-Z0-9]*)(?:\.git)?)((?:/[a-zA-Z][-a-zA-Z0-9]*)*)$`)
 	bbRegex = regexp.MustCompile(`^(?P<root>bitbucket\.org(?P<bitname>/[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+))((?:/[A-Za-z0-9_.\-]+)*)$`)

--- a/deduce_test.go
+++ b/deduce_test.go
@@ -77,14 +77,30 @@ var pathDeductionFixtures = map[string][]pathDeductionFixture{
 			root: "github.com/sdboyer/gps",
 			mb:   maybeGitSource{url: mkurl("https://github.com/sdboyer/gps")},
 		},
+		{
+			in:   "github.com/sdboyer-/gps/foo",
+			root: "github.com/sdboyer-/gps",
+			mb: maybeSources{
+				maybeGitSource{url: mkurl("https://github.com/sdboyer-/gps")},
+				maybeGitSource{url: mkurl("ssh://git@github.com/sdboyer-/gps")},
+				maybeGitSource{url: mkurl("git://github.com/sdboyer-/gps")},
+				maybeGitSource{url: mkurl("http://github.com/sdboyer-/gps")},
+			},
+		},
+		{
+			in:   "github.com/a/gps/foo",
+			root: "github.com/a/gps",
+			mb: maybeSources{
+				maybeGitSource{url: mkurl("https://github.com/a/gps")},
+				maybeGitSource{url: mkurl("ssh://git@github.com/a/gps")},
+				maybeGitSource{url: mkurl("git://github.com/a/gps")},
+				maybeGitSource{url: mkurl("http://github.com/a/gps")},
+			},
+		},
 		// some invalid github username patterns
 		{
 			in:   "github.com/-sdboyer/gps/foo",
 			rerr: errors.New("github.com/-sdboyer/gps/foo is not a valid path for a source on github.com"),
-		},
-		{
-			in:   "github.com/sdboyer-/gps/foo",
-			rerr: errors.New("github.com/sdboyer-/gps/foo is not a valid path for a source on github.com"),
 		},
 		{
 			in:   "github.com/sdbo.yer/gps/foo",


### PR DESCRIPTION
The current rules for github usernames only allow for alphanumeric
characters or single hyphens and they cannot begin or end with a hyphen.
In the past however github username rules were less strict and we need
to support these (issue #194).

Using the Google BigQuery public github dataset, I've checked the
usernames of all public commits against the currently defined regex in
deduce.go. From these results I've concluded that usernames with
multiple consecutive hyphens and usernames that end with a hyphen were
allowed in the past and do exist. Fortunately these are the only
exceptions I've found, there were no usernames that started with a
hyphen or contained any other special characters.

In addition, this change now also allows one-letter usernames.