### PR TITLE
Don't ignore error in runFromCwd

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -117,11 +117,7 @@ func (e killCmdError) Error() string {
 
 func runFromCwd(cmd string, args ...string) ([]byte, error) {
 	c := newMonitoredCmd(exec.Command(cmd, args...), 2*time.Minute)
-	out, err := c.combinedOutput()
-	if err != nil {
-		err = fmt.Errorf("%s: %s", string(out), err)
-	}
-	return out, nil
+	return c.combinedOutput()
 }
 
 func runFromRepoDir(repo vcs.Repo, cmd string, args ...string) ([]byte, error) {


### PR DESCRIPTION
The error in runFromCwd that could potentially be returned from the command was ignored here, so I've fixed that.

Another thing I noticed (but haven't fixed here) is that the [unwrapVcsErr](https://github.com/sdboyer/gps/blob/40253bee3efcc001cffe26081e20bc86220e3a17/source_errors.go#L12-L21) function actually doesn't include the [Original](https://github.com/Masterminds/vcs/blob/795e20f901c3d561de52811fb3488a2cb2c8588b/errors.go#L100) error, so a user would still not know exactly why something may have failed.