### PR TITLE
Make the vcs_repo tests fail when encountering an error

### DIFF
--- a/vcs_repo_test.go
+++ b/vcs_repo_test.go
@@ -19,7 +19,7 @@ func TestSvnRepo(t *testing.T) {
 
 	tempDir, err := ioutil.TempDir("", "go-vcs-svn-tests")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	defer func() {
 		err = os.RemoveAll(tempDir)
@@ -30,54 +30,54 @@ func TestSvnRepo(t *testing.T) {
 
 	rep, err := vcs.NewSvnRepo("https://github.com/Masterminds/VCSTestRepo/trunk", tempDir+string(os.PathSeparator)+"VCSTestRepo")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	repo := &svnRepo{rep}
 
 	// Do an initial checkout.
 	err = repo.Get()
 	if err != nil {
-		t.Errorf("Unable to checkout SVN repo. Err was %s", err)
+		t.Fatalf("Unable to checkout SVN repo. Err was %#v", err)
 	}
 
 	// Verify SVN repo is a SVN repo
 	if !repo.CheckLocal() {
-		t.Error("Problem checking out repo or SVN CheckLocal is not working")
+		t.Fatal("Problem checking out repo or SVN CheckLocal is not working")
 	}
 
 	// Update the version to a previous version.
 	err = repo.UpdateVersion("r2")
 	if err != nil {
-		t.Errorf("Unable to update SVN repo version. Err was %s", err)
+		t.Fatalf("Unable to update SVN repo version. Err was %s", err)
 	}
 
 	// Use Version to verify we are on the right version.
 	v, err := repo.Version()
-	if v != "2" {
-		t.Error("Error checking checked SVN out version")
-	}
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
+	}
+	if v != "2" {
+		t.Fatal("Error checking checked SVN out version")
 	}
 
 	// Perform an update which should take up back to the latest version.
 	err = repo.Update()
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	// Make sure we are on a newer version because of the update.
 	v, err = repo.Version()
-	if v == "2" {
-		t.Error("Error with version. Still on old version. Update failed")
-	}
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
+	}
+	if v == "2" {
+		t.Fatal("Error with version. Still on old version. Update failed")
 	}
 
 	ci, err := repo.CommitInfo("2")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if ci.Commit != "2" {
 		t.Error("Svn.CommitInfo wrong commit id")
@@ -90,7 +90,7 @@ func TestSvnRepo(t *testing.T) {
 	}
 	ti, err := time.Parse(time.RFC3339Nano, "2015-07-29T13:46:20.000000Z")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if !ti.Equal(ci.Date) {
 		t.Error("Svn.CommitInfo wrong date")
@@ -109,7 +109,7 @@ func TestHgRepo(t *testing.T) {
 
 	tempDir, err := ioutil.TempDir("", "go-vcs-hg-tests")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	defer func() {
@@ -121,7 +121,7 @@ func TestHgRepo(t *testing.T) {
 
 	rep, err := vcs.NewHgRepo("https://bitbucket.org/mattfarina/testhgrepo", tempDir+"/testhgrepo")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	repo := &hgRepo{rep}
@@ -129,41 +129,41 @@ func TestHgRepo(t *testing.T) {
 	// Do an initial clone.
 	err = repo.Get()
 	if err != nil {
-		t.Errorf("Unable to clone Hg repo. Err was %s", err)
+		t.Fatalf("Unable to clone Hg repo. Err was %s", err)
 	}
 
 	// Verify Hg repo is a Hg repo
 	if !repo.CheckLocal() {
-		t.Error("Problem checking out repo or Hg CheckLocal is not working")
+		t.Fatal("Problem checking out repo or Hg CheckLocal is not working")
 	}
 
 	// Set the version using the short hash.
 	err = repo.UpdateVersion("a5494ba2177f")
 	if err != nil {
-		t.Errorf("Unable to update Hg repo version. Err was %s", err)
+		t.Fatalf("Unable to update Hg repo version. Err was %s", err)
 	}
 
 	// Use Version to verify we are on the right version.
 	v, err := repo.Version()
-	if v != "a5494ba2177ff9ef26feb3c155dfecc350b1a8ef" {
-		t.Errorf("Error checking checked out Hg version: %s", v)
-	}
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
+	}
+	if v != "a5494ba2177ff9ef26feb3c155dfecc350b1a8ef" {
+		t.Fatalf("Error checking checked out Hg version: %s", v)
 	}
 
 	// Perform an update.
 	err = repo.Update()
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	v, err = repo.Version()
 	if v != "9c6ccbca73e8a1351c834f33f57f1f7a0329ad35" {
-		t.Errorf("Error checking checked out Hg version: %s", v)
+		t.Fatalf("Error checking checked out Hg version: %s", v)
 	}
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 }
 
@@ -174,7 +174,7 @@ func TestGitRepo(t *testing.T) {
 
 	tempDir, err := ioutil.TempDir("", "go-vcs-git-tests")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	defer func() {
@@ -186,7 +186,7 @@ func TestGitRepo(t *testing.T) {
 
 	rep, err := vcs.NewGitRepo("https://github.com/Masterminds/VCSTestRepo", tempDir+"/VCSTestRepo")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	repo := &gitRepo{rep}
@@ -194,32 +194,32 @@ func TestGitRepo(t *testing.T) {
 	// Do an initial clone.
 	err = repo.Get()
 	if err != nil {
-		t.Errorf("Unable to clone Git repo. Err was %s", err)
+		t.Fatalf("Unable to clone Git repo. Err was %s", err)
 	}
 
 	// Verify Git repo is a Git repo
 	if !repo.CheckLocal() {
-		t.Error("Problem checking out repo or Git CheckLocal is not working")
+		t.Fatal("Problem checking out repo or Git CheckLocal is not working")
 	}
 
 	// Perform an update.
 	err = repo.Update()
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	v, err := repo.Current()
 	if err != nil {
-		t.Errorf("Error trying Git Current: %s", err)
+		t.Fatalf("Error trying Git Current: %s", err)
 	}
 	if v != "master" {
-		t.Errorf("Current failed to detect Git on tip of master. Got version: %s", v)
+		t.Fatalf("Current failed to detect Git on tip of master. Got version: %s", v)
 	}
 
 	// Set the version using the short hash.
 	err = repo.UpdateVersion("806b07b")
 	if err != nil {
-		t.Errorf("Unable to update Git repo version. Err was %s", err)
+		t.Fatalf("Unable to update Git repo version. Err was %s", err)
 	}
 
 	// Once a ref has been checked out the repo is in a detached head state.
@@ -228,16 +228,16 @@ func TestGitRepo(t *testing.T) {
 	// skipping that here.
 	err = repo.Update()
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	// Use Version to verify we are on the right version.
 	v, err = repo.Version()
-	if v != "806b07b08faa21cfbdae93027904f80174679402" {
-		t.Error("Error checking checked out Git version")
-	}
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
+	}
+	if v != "806b07b08faa21cfbdae93027904f80174679402" {
+		t.Fatal("Error checking checked out Git version")
 	}
 }
 
@@ -248,7 +248,7 @@ func TestBzrRepo(t *testing.T) {
 
 	tempDir, err := ioutil.TempDir("", "go-vcs-bzr-tests")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	defer func() {
@@ -268,41 +268,41 @@ func TestBzrRepo(t *testing.T) {
 	// Do an initial clone.
 	err = repo.Get()
 	if err != nil {
-		t.Errorf("Unable to clone Bzr repo. Err was %s", err)
+		t.Fatalf("Unable to clone Bzr repo. Err was %s", err)
 	}
 
 	// Verify Bzr repo is a Bzr repo
 	if !repo.CheckLocal() {
-		t.Error("Problem checking out repo or Bzr CheckLocal is not working")
+		t.Fatal("Problem checking out repo or Bzr CheckLocal is not working")
 	}
 
 	v, err := repo.Current()
 	if err != nil {
-		t.Errorf("Error trying Bzr Current: %s", err)
+		t.Fatalf("Error trying Bzr Current: %s", err)
 	}
 	if v != "-1" {
-		t.Errorf("Current failed to detect Bzr on tip of branch. Got version: %s", v)
+		t.Fatalf("Current failed to detect Bzr on tip of branch. Got version: %s", v)
 	}
 
 	err = repo.UpdateVersion("2")
 	if err != nil {
-		t.Errorf("Unable to update Bzr repo version. Err was %s", err)
+		t.Fatalf("Unable to update Bzr repo version. Err was %s", err)
 	}
 
 	// Use Version to verify we are on the right version.
 	v, err = repo.Version()
-	if v != "2" {
-		t.Error("Error checking checked out Bzr version")
-	}
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
+	}
+	if v != "2" {
+		t.Fatal("Error checking checked out Bzr version")
 	}
 
 	v, err = repo.Current()
 	if err != nil {
-		t.Errorf("Error trying Bzr Current: %s", err)
+		t.Fatalf("Error trying Bzr Current: %s", err)
 	}
 	if v != "2" {
-		t.Errorf("Current failed to detect Bzr on rev 2 of branch. Got version: %s", v)
+		t.Fatalf("Current failed to detect Bzr on rev 2 of branch. Got version: %s", v)
 	}
 }


### PR DESCRIPTION
Calling `t.Error` is not enough when encountering an error. While this
marks the test as failed, it won't actually prevent the test from
continuing to run with invalid state. I've replaced these instances with
`t.Fatal`.

There looks to be plenty of opportunity to refactor these tests, but
that's better done in a follow up PR. I've made the smallest change
possible to make these tests not panic in case of errors.

See #200.
