### PR TITLE
Move LockDiff from dep into gps

### DIFF
--- a/lockdiff.go
+++ b/lockdiff.go
@@ -11,13 +11,17 @@ import (
 // * Added: Previous = nil, Current != nil
 // * Deleted: Previous != nil, Current = nil
 // * Modified: Previous != nil, Current != nil
-//
+// * No Change: Previous = Current, or a nil pointer
 type StringDiff struct {
 	Previous string
 	Current  string
 }
 
-func (diff StringDiff) String() string {
+func (diff *StringDiff) String() string {
+	if diff == nil {
+		return ""
+	}
+
 	if diff.Previous == "" && diff.Current != "" {
 		return fmt.Sprintf("+ %s", diff.Current)
 	}
@@ -107,12 +111,12 @@ func DiffLocks(l1 Lock, l2 Lock) *LockDiff {
 					diff.Modify = append(diff.Modify, *pdiff)
 				}
 				i2next = i2 + 1 // Don't evaluate to this again
-			case -1: // Found a new project
+			case +1: // Found a new project
 				add := buildLockedProjectDiff(lp2)
 				diff.Add = append(diff.Add, add)
 				i2next = i2 + 1 // Don't evaluate to this again
 				continue        // Keep looking for a matching project
-			case +1: // Project has been removed, handled below
+			case -1: // Project has been removed, handled below
 				break
 			}
 

--- a/lockdiff.go
+++ b/lockdiff.go
@@ -144,7 +144,7 @@ func DiffLocks(l1 Lock, l2 Lock) *LockDiff {
 
 func buildLockedProjectDiff(lp LockedProject) LockedProjectDiff {
 	s2 := lp.pi.Source
-	r2, b2, v2 := GetVersionInfo(lp.Version())
+	r2, b2, v2 := VersionComponentStrings(lp.Version())
 
 	var rev, version, branch, source *StringDiff
 	if s2 != "" {
@@ -185,8 +185,8 @@ func DiffProjects(lp1 LockedProject, lp2 LockedProject) *LockedProjectDiff {
 		diff.Source = &StringDiff{Previous: s1, Current: s2}
 	}
 
-	r1, b1, v1 := GetVersionInfo(lp1.Version())
-	r2, b2, v2 := GetVersionInfo(lp2.Version())
+	r1, b1, v1 := VersionComponentStrings(lp1.Version())
+	r2, b2, v2 := VersionComponentStrings(lp2.Version())
 	if r1 != r2 {
 		diff.Revision = &StringDiff{Previous: r1, Current: r2}
 	}

--- a/lockdiff.go
+++ b/lockdiff.go
@@ -1,0 +1,249 @@
+package gps
+
+import (
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// StringDiff represents a modified string value.
+// * Added: Previous = nil, Current != nil
+// * Deleted: Previous != nil, Current = nil
+// * Modified: Previous != nil, Current != nil
+//
+type StringDiff struct {
+	Previous string
+	Current  string
+}
+
+func (diff StringDiff) String() string {
+	if diff.Previous == "" && diff.Current != "" {
+		return fmt.Sprintf("+ %s", diff.Current)
+	}
+
+	if diff.Previous != "" && diff.Current == "" {
+		return fmt.Sprintf("- %s", diff.Previous)
+	}
+
+	if diff.Previous != diff.Current {
+		return fmt.Sprintf("%s -> %s", diff.Previous, diff.Current)
+	}
+
+	return diff.Current
+}
+
+// LockDiff is the set of differences between an existing lock file and an updated lock file.
+// Fields are only populated when there is a difference, otherwise they are empty.
+type LockDiff struct {
+	HashDiff *StringDiff
+	Add      []LockedProjectDiff
+	Remove   []LockedProjectDiff
+	Modify   []LockedProjectDiff
+}
+
+// LockedProjectDiff contains the before and after snapshot of a project reference.
+// Fields are only populated when there is a difference, otherwise they are empty.
+type LockedProjectDiff struct {
+	Name     ProjectRoot
+	Source   *StringDiff
+	Version  *StringDiff
+	Branch   *StringDiff
+	Revision *StringDiff
+	Packages []StringDiff
+}
+
+// DiffLocks compares two locks and identifies the differences between them.
+// Returns nil if there are no differences.
+func DiffLocks(l1 Lock, l2 Lock) *LockDiff {
+	// Default nil locks to empty locks, so that we can still generate a diff
+	if l1 == nil {
+		l1 = &SimpleLock{}
+	}
+	if l2 == nil {
+		l2 = &SimpleLock{}
+	}
+
+	p1, p2 := l1.Projects(), l2.Projects()
+
+	// Check if the slices are sorted already. If they are, we can compare
+	// without copying. Otherwise, we have to copy to avoid altering the
+	// original input.
+	sp1, sp2 := lpsorter(p1), lpsorter(p2)
+	if len(p1) > 1 && !sort.IsSorted(sp1) {
+		p1 = make([]LockedProject, len(p1))
+		copy(p1, l1.Projects())
+		sort.Sort(lpsorter(p1))
+	}
+	if len(p2) > 1 && !sort.IsSorted(sp2) {
+		p2 = make([]LockedProject, len(p2))
+		copy(p2, l2.Projects())
+		sort.Sort(lpsorter(p2))
+	}
+
+	diff := LockDiff{}
+
+	h1 := hex.EncodeToString(l1.InputHash())
+	h2 := hex.EncodeToString(l2.InputHash())
+	if h1 != h2 {
+		diff.HashDiff = &StringDiff{Previous: h1, Current: h2}
+	}
+
+	var i2next int
+	for i1 := 0; i1 < len(p1); i1++ {
+		lp1 := p1[i1]
+		pr1 := lp1.pi.ProjectRoot
+
+		var matched bool
+		for i2 := i2next; i2 < len(p2); i2++ {
+			lp2 := p2[i2]
+			pr2 := lp2.pi.ProjectRoot
+
+			switch strings.Compare(string(pr1), string(pr2)) {
+			case 0: // Found a matching project
+				matched = true
+				pdiff := DiffProjects(lp1, lp2)
+				if pdiff != nil {
+					diff.Modify = append(diff.Modify, *pdiff)
+				}
+				i2next = i2 + 1 // Don't evaluate to this again
+			case -1: // Found a new project
+				add := buildLockedProjectDiff(lp2)
+				diff.Add = append(diff.Add, add)
+				i2next = i2 + 1 // Don't evaluate to this again
+				continue        // Keep looking for a matching project
+			case +1: // Project has been removed, handled below
+				break
+			}
+
+			break // Done evaluating this project, move onto the next
+		}
+
+		if !matched {
+			remove := buildLockedProjectDiff(lp1)
+			diff.Remove = append(diff.Remove, remove)
+		}
+	}
+
+	// Anything that still hasn't been evaluated are adds
+	for i2 := i2next; i2 < len(p2); i2++ {
+		lp2 := p2[i2]
+		add := buildLockedProjectDiff(lp2)
+		diff.Add = append(diff.Add, add)
+	}
+
+	if diff.HashDiff == nil && len(diff.Add) == 0 && len(diff.Remove) == 0 && len(diff.Modify) == 0 {
+		return nil // The locks are the equivalent
+	}
+	return &diff
+}
+
+func buildLockedProjectDiff(lp LockedProject) LockedProjectDiff {
+	s2 := lp.pi.Source
+	r2, b2, v2 := GetVersionInfo(lp.Version())
+
+	var rev, version, branch, source *StringDiff
+	if s2 != "" {
+		source = &StringDiff{Previous: s2, Current: s2}
+	}
+	if r2 != "" {
+		rev = &StringDiff{Previous: r2, Current: r2}
+	}
+	if b2 != "" {
+		branch = &StringDiff{Previous: b2, Current: b2}
+	}
+	if v2 != "" {
+		version = &StringDiff{Previous: v2, Current: v2}
+	}
+
+	add := LockedProjectDiff{
+		Name:     lp.pi.ProjectRoot,
+		Source:   source,
+		Revision: rev,
+		Version:  version,
+		Branch:   branch,
+		Packages: make([]StringDiff, len(lp.Packages())),
+	}
+	for i, pkg := range lp.Packages() {
+		add.Packages[i] = StringDiff{Previous: pkg, Current: pkg}
+	}
+	return add
+}
+
+// DiffProjects compares two projects and identifies the differences between them.
+// Returns nil if there are no differences
+func DiffProjects(lp1 LockedProject, lp2 LockedProject) *LockedProjectDiff {
+	diff := LockedProjectDiff{Name: lp1.pi.ProjectRoot}
+
+	s1 := lp1.pi.Source
+	s2 := lp2.pi.Source
+	if s1 != s2 {
+		diff.Source = &StringDiff{Previous: s1, Current: s2}
+	}
+
+	r1, b1, v1 := GetVersionInfo(lp1.Version())
+	r2, b2, v2 := GetVersionInfo(lp2.Version())
+	if r1 != r2 {
+		diff.Revision = &StringDiff{Previous: r1, Current: r2}
+	}
+	if b1 != b2 {
+		diff.Branch = &StringDiff{Previous: b1, Current: b2}
+	}
+	if v1 != v2 {
+		diff.Version = &StringDiff{Previous: v1, Current: v2}
+	}
+
+	p1 := lp1.Packages()
+	p2 := lp2.Packages()
+	if !sort.StringsAreSorted(p1) {
+		p1 = make([]string, len(p1))
+		copy(p1, lp1.Packages())
+		sort.Strings(p1)
+	}
+	if !sort.StringsAreSorted(p2) {
+		p2 = make([]string, len(p2))
+		copy(p2, lp2.Packages())
+		sort.Strings(p2)
+	}
+
+	var i2next int
+	for i1 := 0; i1 < len(p1); i1++ {
+		pkg1 := p1[i1]
+
+		var matched bool
+		for i2 := i2next; i2 < len(p2); i2++ {
+			pkg2 := p2[i2]
+
+			switch strings.Compare(pkg1, pkg2) {
+			case 0: // Found matching package
+				matched = true
+				i2next = i2 + 1 // Don't evaluate to this again
+			case +1: // Found a new package
+				add := StringDiff{Current: pkg2}
+				diff.Packages = append(diff.Packages, add)
+				i2next = i2 + 1 // Don't evaluate to this again
+				continue        // Keep looking for a match
+			case -1: // Package has been removed (handled below)
+				break
+			}
+
+			break // Done evaluating this package, move onto the next
+		}
+
+		if !matched {
+			diff.Packages = append(diff.Packages, StringDiff{Previous: pkg1})
+		}
+	}
+
+	// Anything that still hasn't been evaluated are adds
+	for i2 := i2next; i2 < len(p2); i2++ {
+		pkg2 := p2[i2]
+		add := StringDiff{Current: pkg2}
+		diff.Packages = append(diff.Packages, add)
+	}
+
+	if diff.Source == nil && diff.Version == nil && diff.Revision == nil && len(diff.Packages) == 0 {
+		return nil // The projects are equivalent
+	}
+	return &diff
+}

--- a/lockdiff_test.go
+++ b/lockdiff_test.go
@@ -444,3 +444,54 @@ func TestDiffLocks_ModifyHash(t *testing.T) {
 		t.Fatalf("Expected diff.HashDiff to be '%s', got '%s'", want, got)
 	}
 }
+
+func TestDiffLocks_EmptyInitialLock(t *testing.T) {
+	h2, _ := hex.DecodeString("abc123")
+	l2 := safeLock{
+		h: h2,
+		p: []LockedProject{
+			{pi: ProjectIdentifier{ProjectRoot: "github.com/foo/bar"}, v: NewVersion("v1.0.0")},
+		},
+	}
+
+	diff := DiffLocks(nil, l2)
+
+	wantHash := "+ abc123"
+	gotHash := diff.HashDiff.String()
+	if gotHash != wantHash {
+		t.Fatalf("Expected diff.HashDiff to be '%s', got '%s'", wantHash, gotHash)
+	}
+
+	if len(diff.Add) != 1 {
+		t.Fatalf("Expected diff.Add to contain 1 project, got %d", len(diff.Add))
+	}
+}
+
+func TestDiffLocks_EmptyFinalLock(t *testing.T) {
+	h1, _ := hex.DecodeString("abc123")
+	l1 := safeLock{
+		h: h1,
+		p: []LockedProject{
+			{pi: ProjectIdentifier{ProjectRoot: "github.com/foo/bar"}, v: NewVersion("v1.0.0")},
+		},
+	}
+
+	diff := DiffLocks(l1, nil)
+
+	wantHash := "- abc123"
+	gotHash := diff.HashDiff.String()
+	if gotHash != wantHash {
+		t.Fatalf("Expected diff.HashDiff to be '%s', got '%s'", wantHash, gotHash)
+	}
+
+	if len(diff.Remove) != 1 {
+		t.Fatalf("Expected diff.Remove to contain 1 project, got %d", len(diff.Remove))
+	}
+}
+
+func TestDiffLocks_EmptyLocks(t *testing.T) {
+	diff := DiffLocks(nil, nil)
+	if diff != nil {
+		t.Fatal("Expected the diff to be empty")
+	}
+}

--- a/lockdiff_test.go
+++ b/lockdiff_test.go
@@ -1,0 +1,446 @@
+package gps
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
+
+func TestStringDiff_NoChange(t *testing.T) {
+	diff := StringDiff{Previous: "foo", Current: "foo"}
+	want := "foo"
+	got := diff.String()
+	if got != want {
+		t.Fatalf("Expected '%s', got '%s'", want, got)
+	}
+}
+
+func TestStringDiff_Add(t *testing.T) {
+	diff := StringDiff{Current: "foo"}
+	got := diff.String()
+	if got != "+ foo" {
+		t.Fatalf("Expected '+ foo', got '%s'", got)
+	}
+}
+
+func TestStringDiff_Remove(t *testing.T) {
+	diff := StringDiff{Previous: "foo"}
+	want := "- foo"
+	got := diff.String()
+	if got != want {
+		t.Fatalf("Expected '%s', got '%s'", want, got)
+	}
+}
+
+func TestStringDiff_Modify(t *testing.T) {
+	diff := StringDiff{Previous: "foo", Current: "bar"}
+	want := "foo -> bar"
+	got := diff.String()
+	if got != want {
+		t.Fatalf("Expected '%s', got '%s'", want, got)
+	}
+}
+
+func TestDiffProjects_NoChange(t *testing.T) {
+	p1 := NewLockedProject(mkPI("github.com/sdboyer/gps"), NewVersion("v0.10.0"), []string{"gps"})
+	p2 := NewLockedProject(mkPI("github.com/sdboyer/gps"), NewVersion("v0.10.0"), []string{"gps"})
+
+	diff := DiffProjects(p1, p2)
+	if diff != nil {
+		t.Fatal("Expected the diff to be nil")
+	}
+}
+
+func TestDiffProjects_Modify(t *testing.T) {
+	p1 := LockedProject{
+		pi:   ProjectIdentifier{ProjectRoot: "github.com/foo/bar"},
+		v:    NewBranch("master"),
+		r:    "abc123",
+		pkgs: []string{"baz", "qux"},
+	}
+
+	p2 := LockedProject{
+		pi:   ProjectIdentifier{ProjectRoot: "github.com/foo/bar", Source: "https://github.com/mcfork/gps.git"},
+		v:    NewVersion("v1.0.0"),
+		r:    "def456",
+		pkgs: []string{"baz", "derp"},
+	}
+
+	diff := DiffProjects(p1, p2)
+	if diff == nil {
+		t.Fatal("Expected the diff to be populated")
+	}
+
+	wantSource := "+ https://github.com/mcfork/gps.git"
+	gotSource := diff.Source.String()
+	if gotSource != wantSource {
+		t.Fatalf("Expected diff.Source to be '%s', got '%s'", wantSource, diff.Source)
+	}
+
+	wantVersion := "+ v1.0.0"
+	gotVersion := diff.Version.String()
+	if gotVersion != wantVersion {
+		t.Fatalf("Expected diff.Version to be '%s', got '%s'", wantVersion, gotVersion)
+	}
+
+	wantRevision := "abc123 -> def456"
+	gotRevision := diff.Revision.String()
+	if gotRevision != wantRevision {
+		t.Fatalf("Expected diff.Revision to be '%s', got '%s'", wantRevision, gotRevision)
+	}
+
+	wantBranch := "- master"
+	gotBranch := diff.Branch.String()
+	if gotBranch != wantBranch {
+		t.Fatalf("Expected diff.Branch to be '%s', got '%s'", wantBranch, gotBranch)
+	}
+
+	fmtPkgs := func(pkgs []StringDiff) string {
+		b := bytes.NewBufferString("[")
+		for _, pkg := range pkgs {
+			b.WriteString(pkg.String())
+			b.WriteString(",")
+		}
+		b.WriteString("]")
+		return b.String()
+	}
+
+	wantPackages := "[+ derp,- qux,]"
+	gotPackages := fmtPkgs(diff.Packages)
+	if gotPackages != wantPackages {
+		t.Fatalf("Expected diff.Packages to be '%s', got '%s'", wantPackages, gotPackages)
+	}
+}
+
+func TestDiffProjects_AddPackages(t *testing.T) {
+	p1 := LockedProject{
+		pi:   ProjectIdentifier{ProjectRoot: "github.com/foo/bar"},
+		v:    NewBranch("master"),
+		r:    "abc123",
+		pkgs: []string{"foobar"},
+	}
+
+	p2 := LockedProject{
+		pi:   ProjectIdentifier{ProjectRoot: "github.com/foo/bar", Source: "https://github.com/mcfork/gps.git"},
+		v:    NewVersion("v1.0.0"),
+		r:    "def456",
+		pkgs: []string{"bazqux", "foobar", "zugzug"},
+	}
+
+	diff := DiffProjects(p1, p2)
+	if diff == nil {
+		t.Fatal("Expected the diff to be populated")
+	}
+
+	if len(diff.Packages) != 2 {
+		t.Fatalf("Expected diff.Packages to have 2 packages, got %d", len(diff.Packages))
+	}
+
+	want0 := "+ bazqux"
+	got0 := diff.Packages[0].String()
+	if got0 != want0 {
+		t.Fatalf("Expected diff.Packages[0] to contain %s, got %s", want0, got0)
+	}
+
+	want1 := "+ zugzug"
+	got1 := diff.Packages[1].String()
+	if got1 != want1 {
+		t.Fatalf("Expected diff.Packages[1] to contain %s, got %s", want1, got1)
+	}
+}
+
+func TestDiffProjects_RemovePackages(t *testing.T) {
+	p1 := LockedProject{
+		pi:   ProjectIdentifier{ProjectRoot: "github.com/foo/bar"},
+		v:    NewBranch("master"),
+		r:    "abc123",
+		pkgs: []string{"athing", "foobar"},
+	}
+
+	p2 := LockedProject{
+		pi:   ProjectIdentifier{ProjectRoot: "github.com/foo/bar", Source: "https://github.com/mcfork/gps.git"},
+		v:    NewVersion("v1.0.0"),
+		r:    "def456",
+		pkgs: []string{"bazqux"},
+	}
+
+	diff := DiffProjects(p1, p2)
+	if diff == nil {
+		t.Fatal("Expected the diff to be populated")
+	}
+
+	if len(diff.Packages) > 3 {
+		t.Fatalf("Expected diff.Packages to have 3 packages, got %d", len(diff.Packages))
+	}
+
+	want0 := "- athing"
+	got0 := diff.Packages[0].String()
+	if got0 != want0 {
+		t.Fatalf("Expected diff.Packages[0] to contain %s, got %s", want0, got0)
+	}
+
+	// diff.Packages[1] is '+ bazqux'
+
+	want2 := "- foobar"
+	got2 := diff.Packages[2].String()
+	if got2 != want2 {
+		t.Fatalf("Expected diff.Packages[2] to contain %s, got %s", want2, got2)
+	}
+}
+
+func TestDiffLocks_NoChange(t *testing.T) {
+	l1 := safeLock{
+		h: []byte("abc123"),
+		p: []LockedProject{
+			{pi: ProjectIdentifier{ProjectRoot: "github.com/foo/bar"}, v: NewVersion("v1.0.0")},
+		},
+	}
+	l2 := safeLock{
+		h: []byte("abc123"),
+		p: []LockedProject{
+			{pi: ProjectIdentifier{ProjectRoot: "github.com/foo/bar"}, v: NewVersion("v1.0.0")},
+		},
+	}
+
+	diff := DiffLocks(l1, l2)
+	if diff != nil {
+		t.Fatal("Expected the diff to be nil")
+	}
+}
+
+func TestDiffLocks_AddProjects(t *testing.T) {
+	l1 := safeLock{
+		h: []byte("abc123"),
+		p: []LockedProject{
+			{pi: ProjectIdentifier{ProjectRoot: "github.com/foo/bar"}, v: NewVersion("v1.0.0")},
+		},
+	}
+	l2 := safeLock{
+		h: []byte("abc123"),
+		p: []LockedProject{
+			{
+				pi:   ProjectIdentifier{ProjectRoot: "github.com/baz/qux", Source: "https://github.com/mcfork/bazqux.git"},
+				v:    NewVersion("v0.5.0"),
+				r:    "def456",
+				pkgs: []string{"p1", "p2"},
+			},
+			{pi: ProjectIdentifier{ProjectRoot: "github.com/foo/bar"}, v: NewVersion("v1.0.0")},
+			{pi: ProjectIdentifier{ProjectRoot: "github.com/zug/zug"}, v: NewVersion("v1.0.0")},
+		},
+	}
+
+	diff := DiffLocks(l1, l2)
+	if diff == nil {
+		t.Fatal("Expected the diff to be populated")
+	}
+
+	if len(diff.Add) != 2 {
+		t.Fatalf("Expected diff.Add to have 2 projects, got %d", len(diff.Add))
+	}
+
+	want0 := "github.com/baz/qux"
+	got0 := string(diff.Add[0].Name)
+	if got0 != want0 {
+		t.Fatalf("Expected diff.Add[0] to contain %s, got %s", want0, got0)
+	}
+
+	want1 := "github.com/zug/zug"
+	got1 := string(diff.Add[1].Name)
+	if got1 != want1 {
+		t.Fatalf("Expected diff.Add[1] to contain %s, got %s", want1, got1)
+	}
+
+	add0 := diff.Add[0]
+	wantSource := "https://github.com/mcfork/bazqux.git"
+	gotSource := add0.Source.String()
+	if gotSource != wantSource {
+		t.Fatalf("Expected diff.Add[0].Source to be '%s', got '%s'", wantSource, add0.Source)
+	}
+
+	wantVersion := "v0.5.0"
+	gotVersion := add0.Version.String()
+	if gotVersion != wantVersion {
+		t.Fatalf("Expected diff.Add[0].Version to be '%s', got '%s'", wantVersion, gotVersion)
+	}
+
+	wantRevision := "def456"
+	gotRevision := add0.Revision.String()
+	if gotRevision != wantRevision {
+		t.Fatalf("Expected diff.Add[0].Revision to be '%s', got '%s'", wantRevision, gotRevision)
+	}
+
+	wantBranch := ""
+	gotBranch := add0.Branch.String()
+	if gotBranch != wantBranch {
+		t.Fatalf("Expected diff.Add[0].Branch to be '%s', got '%s'", wantBranch, gotBranch)
+	}
+
+	fmtPkgs := func(pkgs []StringDiff) string {
+		b := bytes.NewBufferString("[")
+		for _, pkg := range pkgs {
+			b.WriteString(pkg.String())
+			b.WriteString(",")
+		}
+		b.WriteString("]")
+		return b.String()
+	}
+
+	wantPackages := "[p1,p2,]"
+	gotPackages := fmtPkgs(add0.Packages)
+	if gotPackages != wantPackages {
+		t.Fatalf("Expected diff.Add[0].Packages to be '%s', got '%s'", wantPackages, gotPackages)
+	}
+}
+
+func TestDiffLocks_RemoveProjects(t *testing.T) {
+	l1 := safeLock{
+		h: []byte("abc123"),
+		p: []LockedProject{
+			{
+				pi:   ProjectIdentifier{ProjectRoot: "github.com/a/thing", Source: "https://github.com/mcfork/athing.git"},
+				v:    NewBranch("master"),
+				r:    "def456",
+				pkgs: []string{"p1", "p2"},
+			},
+			{pi: ProjectIdentifier{ProjectRoot: "github.com/foo/bar"}, v: NewVersion("v1.0.0")},
+		},
+	}
+	l2 := safeLock{
+		h: []byte("abc123"),
+		p: []LockedProject{
+			{pi: ProjectIdentifier{ProjectRoot: "github.com/baz/qux"}, v: NewVersion("v1.0.0")},
+		},
+	}
+
+	diff := DiffLocks(l1, l2)
+	if diff == nil {
+		t.Fatal("Expected the diff to be populated")
+	}
+
+	if len(diff.Remove) != 2 {
+		t.Fatalf("Expected diff.Remove to have 2 projects, got %d", len(diff.Remove))
+	}
+
+	want0 := "github.com/a/thing"
+	got0 := string(diff.Remove[0].Name)
+	if got0 != want0 {
+		t.Fatalf("Expected diff.Remove[0] to contain %s, got %s", want0, got0)
+	}
+
+	want1 := "github.com/foo/bar"
+	got1 := string(diff.Remove[1].Name)
+	if got1 != want1 {
+		t.Fatalf("Expected diff.Remove[1] to contain %s, got %s", want1, got1)
+	}
+
+	remove0 := diff.Remove[0]
+	wantSource := "https://github.com/mcfork/athing.git"
+	gotSource := remove0.Source.String()
+	if gotSource != wantSource {
+		t.Fatalf("Expected diff.Remove[0].Source to be '%s', got '%s'", wantSource, remove0.Source)
+	}
+
+	wantVersion := ""
+	gotVersion := remove0.Version.String()
+	if gotVersion != wantVersion {
+		t.Fatalf("Expected diff.Remove[0].Version to be '%s', got '%s'", wantVersion, gotVersion)
+	}
+
+	wantRevision := "def456"
+	gotRevision := remove0.Revision.String()
+	if gotRevision != wantRevision {
+		t.Fatalf("Expected diff.Remove[0].Revision to be '%s', got '%s'", wantRevision, gotRevision)
+	}
+
+	wantBranch := "master"
+	gotBranch := remove0.Branch.String()
+	if gotBranch != wantBranch {
+		t.Fatalf("Expected diff.Remove[0].Branch to be '%s', got '%s'", wantBranch, gotBranch)
+	}
+
+	fmtPkgs := func(pkgs []StringDiff) string {
+		b := bytes.NewBufferString("[")
+		for _, pkg := range pkgs {
+			b.WriteString(pkg.String())
+			b.WriteString(",")
+		}
+		b.WriteString("]")
+		return b.String()
+	}
+
+	wantPackages := "[p1,p2,]"
+	gotPackages := fmtPkgs(remove0.Packages)
+	if gotPackages != wantPackages {
+		t.Fatalf("Expected diff.Remove[0].Packages to be '%s', got '%s'", wantPackages, gotPackages)
+	}
+}
+
+func TestDiffLocks_ModifyProjects(t *testing.T) {
+	l1 := safeLock{
+		h: []byte("abc123"),
+		p: []LockedProject{
+			{pi: ProjectIdentifier{ProjectRoot: "github.com/foo/bar"}, v: NewVersion("v1.0.0")},
+			{pi: ProjectIdentifier{ProjectRoot: "github.com/foo/bu"}, v: NewVersion("v1.0.0")},
+			{pi: ProjectIdentifier{ProjectRoot: "github.com/zig/zag"}, v: NewVersion("v1.0.0")},
+		},
+	}
+	l2 := safeLock{
+		h: []byte("abc123"),
+		p: []LockedProject{
+			{pi: ProjectIdentifier{ProjectRoot: "github.com/baz/qux"}, v: NewVersion("v1.0.0")},
+			{pi: ProjectIdentifier{ProjectRoot: "github.com/foo/bar"}, v: NewVersion("v2.0.0")},
+			{pi: ProjectIdentifier{ProjectRoot: "github.com/zig/zag"}, v: NewVersion("v2.0.0")},
+			{pi: ProjectIdentifier{ProjectRoot: "github.com/zug/zug"}, v: NewVersion("v1.0.0")},
+		},
+	}
+
+	diff := DiffLocks(l1, l2)
+	if diff == nil {
+		t.Fatal("Expected the diff to be populated")
+	}
+
+	if len(diff.Modify) != 2 {
+		t.Fatalf("Expected diff.Remove to have 2 projects, got %d", len(diff.Remove))
+	}
+
+	want0 := "github.com/foo/bar"
+	got0 := string(diff.Modify[0].Name)
+	if got0 != want0 {
+		t.Fatalf("Expected diff.Modify[0] to contain %s, got %s", want0, got0)
+	}
+
+	want1 := "github.com/zig/zag"
+	got1 := string(diff.Modify[1].Name)
+	if got1 != want1 {
+		t.Fatalf("Expected diff.Modify[1] to contain %s, got %s", want1, got1)
+	}
+}
+
+func TestDiffLocks_ModifyHash(t *testing.T) {
+	h1, _ := hex.DecodeString("abc123")
+	l1 := safeLock{
+		h: h1,
+		p: []LockedProject{
+			{pi: ProjectIdentifier{ProjectRoot: "github.com/foo/bar"}, v: NewVersion("v1.0.0")},
+		},
+	}
+
+	h2, _ := hex.DecodeString("def456")
+	l2 := safeLock{
+		h: h2,
+		p: []LockedProject{
+			{pi: ProjectIdentifier{ProjectRoot: "github.com/foo/bar"}, v: NewVersion("v1.0.0")},
+		},
+	}
+
+	diff := DiffLocks(l1, l2)
+	if diff == nil {
+		t.Fatal("Expected the diff to be populated")
+	}
+
+	want := "abc123 -> def456"
+	got := diff.HashDiff.String()
+	if got != want {
+		t.Fatalf("Expected diff.HashDiff to be '%s', got '%s'", want, got)
+	}
+}

--- a/version.go
+++ b/version.go
@@ -810,3 +810,23 @@ func hidePair(pvl []PairedVersion) []Version {
 	}
 	return vl
 }
+
+// Decompose a Version into the underlying number, branch and revision
+func GetVersionInfo(v Version) (revision string, branch string, version string) {
+	switch tv := v.(type) {
+	case UnpairedVersion:
+	case Revision:
+		revision = tv.String()
+	case PairedVersion:
+		revision = tv.Underlying().String()
+	}
+
+	switch v.Type() {
+	case IsBranch:
+		branch = v.String()
+	case IsSemver, IsVersion:
+		version = v.String()
+	}
+
+	return
+}

--- a/version.go
+++ b/version.go
@@ -811,7 +811,7 @@ func hidePair(pvl []PairedVersion) []Version {
 	return vl
 }
 
-// Decompose a Version into the underlying number, branch and revision
+// GetVersionInfo decomposes a Version into the underlying number, branch and revision
 func GetVersionInfo(v Version) (revision string, branch string, version string) {
 	switch tv := v.(type) {
 	case UnpairedVersion:

--- a/version.go
+++ b/version.go
@@ -811,8 +811,8 @@ func hidePair(pvl []PairedVersion) []Version {
 	return vl
 }
 
-// GetVersionInfo decomposes a Version into the underlying number, branch and revision
-func GetVersionInfo(v Version) (revision string, branch string, version string) {
+// VersionComponentStrings decomposes a Version into the underlying number, branch and revision
+func VersionComponentStrings(v Version) (revision string, branch string, version string) {
 	switch tv := v.(type) {
 	case UnpairedVersion:
 	case Revision:


### PR DESCRIPTION
* Move `LockDiff` and related structs.
* Expose `gps.DiffLocks(l1, l2)` and `gps.DiffProjects(p1, p2)`.
* All the TOML related annotation will remain in dep, using the same `rawX` pattern that locks use.