### PR TITLE
Fix empty out data check

### DIFF
--- a/vcs_source.go
+++ b/vcs_source.go
@@ -170,7 +170,7 @@ func (s *gitSource) listVersions(ctx context.Context) (vlist []PairedVersion, er
 	}
 
 	all := bytes.Split(bytes.TrimSpace(out), []byte("\n"))
-	if len(all) == 0 {
+	if len(all) == 1 && len(all[0]) == 0 {
 		return nil, fmt.Errorf("no data returned from ls-remote")
 	}
 


### PR DESCRIPTION
```go
all := bytes.Split(bytes.TrimSpace(out), []byte("\n"))
if len(all) == 0 {
}
```
It's a wrong way to check if no data. And it may cause `headrev := Revision(all[0][:40])
` panic.
See example below:
```go
package main

import (
	"bytes"
	"fmt"
)

func main() {
	out := []byte("")
	all := bytes.Split(bytes.TrimSpace(out), []byte("\n"))
	fmt.Printf("%d %d\n", len(all), len(all[0]))
}
```
It outputs:
```
1 0
```
